### PR TITLE
Fix minor math error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,13 @@ return a new object, leaving the original object unaffected:
 $ten = BigInteger::of(10);
 
 echo $ten->plus(5); // 15
-echo $ten->multipliedBy(3); // 30
+echo $ten->multipliedBy(3); // 45
 ```
 
 The methods can be chained for better readability:
 
 ```php
-echo BigInteger::of(10)->plus(5)->multipliedBy(3); // 30
+echo BigInteger::of(10)->plus(5)->multipliedBy(3); // 45
 ```
 
 #### Parameter types

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ return a new object, leaving the original object unaffected:
 $ten = BigInteger::of(10);
 
 echo $ten->plus(5); // 15
-echo $ten->multipliedBy(3); // 45
+echo $ten->multipliedBy(3); // 30
 ```
 
-The methods can be chained for better readability:
+The methods can be chained for better readability when acting upon the previous result:
 
 ```php
 echo BigInteger::of(10)->plus(5)->multipliedBy(3); // 45


### PR DESCRIPTION
Very minor typo in the readme - `BigInteger::of(10)->plus(5)->multipliedBy(3)` should be 45.