### PR TITLE
Add bitwise operations to BigInteger

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ And the following exceptions in the [Brick\Math\Exception](http://brick.io/math/
 - [IntegerOverflowException](https://github.com/brick/math/blob/master/src/Exception/IntegerOverflowException.php): thrown when attempting to convert a too large `BigInteger` to `int`
 - [NumberFormatException](https://github.com/brick/math/blob/master/src/Exception/NumberFormatException.php): thrown when parsing a number string in an invalid format
 - [RoundingNecessaryException](https://github.com/brick/math/blob/master/src/Exception/RoundingNecessaryException.php): thrown when the result of the operation cannot be represented without explicit rounding
+- [ShiftException](https://github.com/brick/math/blob/master/src/Exception/ShiftException.php): thrown when a shift with a negative distance is performed
 
 ### Overview
 

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -7,6 +7,8 @@ namespace Brick\Math;
 use Brick\Math\Exception\DivisionByZeroException;
 use Brick\Math\Exception\IntegerOverflowException;
 use Brick\Math\Exception\MathException;
+use Brick\Math\Exception\ShiftException;
+use Brick\Math\Internal\Bitwise;
 use Brick\Math\Internal\Calculator;
 
 /**
@@ -404,6 +406,86 @@ final class BigInteger extends BigNumber
     public function negated() : BigInteger
     {
         return new BigInteger(Calculator::get()->neg($this->value));
+    }
+
+    /**
+     * Returns the integer bitwise-and combined with another integer.
+     *
+     * @param BigNumber|number|string $that The operand. Must be convertible to an integer number.
+     *
+     * @return BigInteger
+     */
+    public function and($that) : BigInteger
+    {
+        $that = BigInteger::of($that);
+
+        return Bitwise::bitwise($this, $that, 'and');
+    }
+
+    /**
+     * Returns the integer bitwise-or combined with another integer.
+     *
+     * @param BigNumber|number|string $that The operand. Must be convertible to an integer number.
+     *
+     * @return BigInteger
+     */
+    public function or($that) : BigInteger
+    {
+        $that = BigInteger::of($that);
+
+        return Bitwise::bitwise($this, $that, 'or');
+    }
+
+    /**
+     * Returns the integer bitwise-xor combined with another integer.
+     *
+     * @param BigNumber|number|string $that The operand. Must be convertible to an integer number.
+     *
+     * @return BigInteger
+     */
+    public function xor($that) : BigInteger
+    {
+        $that = BigInteger::of($that);
+
+        return Bitwise::bitwise($this, $that, 'xor');
+    }
+
+    /**
+     * Returns the integer left shifted by a given number of bits.
+     *
+     * @param int $distance The distance to shift.
+     *
+     * @return BigInteger
+     */
+    public function shiftLeft(int $distance) : BigInteger
+    {
+        if ($distance < 0) {
+            throw new ShiftException('Distance must not be negative.');
+        }
+
+        return $this->multipliedBy(BigInteger::of(2)->power($distance));
+    }
+
+    /**
+     * Returns the integer right shifted by a given number of bits.
+     *
+     * @param int $distance The distance to shift.
+     *
+     * @return BigInteger
+     */
+    public function shiftRight(int $distance) : BigInteger
+    {
+        if ($distance < 0) {
+            throw new ShiftException('Distance must not be negative.');
+        }
+
+        $operand = BigInteger::of(2)->power($distance);
+
+        if ($this->isPositiveOrZero()) {
+            return $this->quotient($operand);
+        }
+
+        return $this->dividedBy($operand, RoundingMode::UP);
     }
 
     /**

--- a/src/Exception/ShiftException.php
+++ b/src/Exception/ShiftException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Math\Exception;
+
+/**
+ * Exception thrown when shift by an invalid distance.
+ */
+class ShiftException extends MathException
+{
+}

--- a/src/Internal/Bitwise.php
+++ b/src/Internal/Bitwise.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Math\Internal;
+
+use Brick\Math\BigInteger;
+
+/**
+ * A helper class to support bitwise operations on BigInteger
+ *
+ * @internal
+ */
+abstract class Bitwise
+{
+    /**
+     * Performs a bitwise operation on a BigInteger number.
+     *
+     * @param BigInteger $x        The base number to operate on.
+     * @param BigInteger $y        The second operand.
+     * @param string     $operator The operator to use, must be "and", "or" or "xor".
+     *
+     * @return BigInteger
+     */
+    public static function bitwise(BigInteger $x, BigInteger $y, string $operator) : BigInteger
+    {
+        $binaryX = self::toBinary($x);
+        $binaryY = self::toBinary($y);
+
+        $maxLength = max(strlen($binaryX), strlen($binaryY));
+        $binaryX = $binaryX[0] . str_pad(substr($binaryX, 1), $maxLength - 1, "\x0", STR_PAD_LEFT);
+        $binaryY = $binaryY[0] . str_pad(substr($binaryY, 1), $maxLength - 1, "\x0", STR_PAD_LEFT);
+
+        $value = '';
+
+        for ($i = 0; $i < $maxLength; ++$i) {
+            switch ($operator) {
+                case 'and':
+                    $value .= $binaryX[$i] & $binaryY[$i];
+                    break;
+
+                case 'or':
+                    $value .= $binaryX[$i] | $binaryY[$i];
+                    break;
+
+                case 'xor':
+                    $value .= $binaryX[$i] ^ $binaryY[$i];
+                    break;
+            }
+        }
+
+        return self::toBigInteger($value);
+    }
+
+    /**
+     * Returns the binary format of a number.
+     *
+     * @param BigInteger $x The number to convert to binary format.
+     *
+     * @return string
+     */
+    private static function toBinary(BigInteger $x) : string
+    {
+        $isNegative = $x->isNegative();
+        $abs = $x->abs();
+        $base = BigInteger::of(256);
+        $bytes = '';
+        $lastByte = true;
+
+        while ($abs->isGreaterThanOrEqualTo($base)) {
+            list($abs, $rest) = $abs->quotientAndRemainder($base);
+            $bytes = chr(
+                $isNegative ?
+                    ($lastByte ? 256 : 255) - $rest->toInt()
+                    : $rest->toInt()
+            ) . $bytes;
+            $lastByte = false;
+        }
+
+        $bytes = chr(
+            $isNegative ?
+                ($lastByte ? 256 : 255) - $abs->toInt()
+                : $abs->toInt()
+        ) . $bytes;
+        $bytes = ($isNegative ? "\xff" : "\x0") . $bytes;
+
+        return $bytes;
+    }
+
+    /**
+     * Returns the BigInteger representation of a binary number.
+     *
+     * @param string $bytes The bytes representing the number.
+     *
+     * @return BigInteger
+     */
+    private static function toBigInteger(string $bytes) : BigInteger
+    {
+        $isNegative = $bytes[0] === "\xff";
+        $base = BigInteger::of(256);
+        $length = strlen($bytes);
+        $value = BigInteger::zero();
+
+        for ($i = 1; $i < $length; ++$i) {
+            $lastByte = ($i === $length - 1);
+            $multiplier = $base->power($length - $i - 1);
+            $value = $value->plus(
+                BigInteger::of(
+                    $isNegative
+                        ? ($lastByte ? 256 : 255) - ord($bytes[$i])
+                        : ord($bytes[$i])
+                )->multipliedBy($multiplier)
+            );
+        }
+
+        return $isNegative ? $value->negated() : $value;
+    }
+}

--- a/tests/BigIntegerTest.php
+++ b/tests/BigIntegerTest.php
@@ -3,6 +3,7 @@
 namespace Brick\Math\Tests;
 
 use Brick\Math\BigInteger;
+use Brick\Math\Exception\ShiftException;
 use Brick\Math\RoundingMode;
 use Brick\Math\Exception\DivisionByZeroException;
 use Brick\Math\Exception\RoundingNecessaryException;
@@ -1479,6 +1480,159 @@ class BigIntegerTest extends AbstractTestCase
             ['0', '0'],
             ['123456789012345678901234567890', '-123456789012345678901234567890'],
             ['-123456789012345678901234567890', '123456789012345678901234567890'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerOr
+     *
+     * @param string $a The base number as a string.
+     * @param string $b The second operand as a string.
+     * @param string $c The expected result.
+     */
+    public function testOr($a, $b, $c)
+    {
+        $this->assertBigIntegerEquals($c, BigInteger::of($a)->or($b));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerOr()
+    {
+        return [
+            ['-1', '-2', '-1'],
+            ['1', '-2', '-1'],
+            ['-1', '2', '-1'],
+            ['0', '1', '1'],
+            ['123456789', '2', '123456791'],
+            ['123456789012345678901234567890', '5', '123456789012345678901234567895'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerAnd
+     *
+     * @param string $a The base number as a string.
+     * @param string $b The second operand as a string.
+     * @param string $c The expected result.
+     */
+    public function testAnd($a, $b, $c)
+    {
+        $this->assertBigIntegerEquals($c, BigInteger::of($a)->and($b));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerAnd()
+    {
+        return [
+            ['-1', '-2', '-2'],
+            ['1', '-2', '0'],
+            ['-1', '2', '2'],
+            ['0', '1', '0'],
+            ['123456789', '123456787', '123456785'],
+            ['-255', '255', '1'],
+            ['-65535', '65535', '1'],
+            ['123456789012345678901234567890', '123456789012345678901234567880', '123456789012345678901234567872'],
+            ['-123456789012345678', '123456789012345678', '2'],
+            ['-123456789012345678901234567890', '123456789012345678901234567880', '8'],
+            ['-123456789012345678901234567890', '123456789012345678901234567890', '2'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerXor
+     *
+     * @param string $a The base number as a string.
+     * @param string $b The second operand as a string.
+     * @param string $c The expected result.
+     */
+    public function testXor($a, $b, $c)
+    {
+        $this->assertBigIntegerEquals($c, BigInteger::of($a)->xor($b));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerXor()
+    {
+        return [
+            ['-1', '-2', '1'],
+            ['1', '-2', '-1'],
+            ['-1', '2', '-3'],
+            ['0', '1', '1'],
+            ['123456789', '123456787', '6'],
+            ['123456789012345678901234567890', '123456789012345678901234567880', '26'],
+        ];
+    }
+
+    /**
+     * @expectedException \Brick\Math\Exception\ShiftException
+     */
+    public function testShiftLeftWithNegativeDistance()
+    {
+        BigInteger::zero()->shiftLeft(-1);
+    }
+
+    /**
+     * @dataProvider providerShiftLeft
+     *
+     * @param string $a The base number as a string.
+     * @param int    $b The distance to shift.
+     * @param string $c The expected shifted result.
+     */
+    public function testShiftLeft($a, $b, $c)
+    {
+        $this->assertBigIntegerEquals($c, BigInteger::of($a)->shiftLeft($b));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerShiftLeft()
+    {
+        return [
+            ['-1', 1, '-2'],
+            ['0', 1, '0'],
+            ['123456789', 1, '246913578'],
+            ['123456789012345678901234567890', 5, '3950617248395061724839506172480'],
+        ];
+    }
+
+    /**
+     * @expectedException \Brick\Math\Exception\ShiftException
+     */
+    public function testShiftRightWithNegativeDistance()
+    {
+        BigInteger::zero()->shiftRight(-1);
+    }
+
+    /**
+     * @dataProvider providerShiftRight
+     *
+     * @param string $a The base number as a string.
+     * @param int    $b The distance to shift.
+     * @param string $c The expected shifted result.
+     */
+    public function testShiftRight($a, $b, $c)
+    {
+        $this->assertBigIntegerEquals($c, BigInteger::of($a)->shiftRight($b));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerShiftRight()
+    {
+        return [
+            ['-3', 1, '-2'],
+            ['-5', 1, '-3'],
+            ['0', 1, '0'],
+            ['123456789', 1, '61728394'],
+            ['123456789012345678901234567890', 5, '3858024656635802465663580246'],
         ];
     }
 


### PR DESCRIPTION
I'm currently working on a CBOR parser and ran into a problem when parsing big integers, so I needed a proper BigInteger implementation. This project seems really well written and supported, so I chose to use it. Sadly, in order to use it, I needed bitwise operations on the integers.

This PR adds the following methods to BigInteger:

- `or($that)`
- `and($that)`
- `xor($that)`
- `shiftLeft(int $distance)`
- `shiftRight(int $distance)`

In order to not pollute the `BigInteger` with implementation details about bitwise operations, all but the shifting is encapsulated in the `Bitwise` class in the internal namespace. As this is an implementation detail, that class is blackbox-tested through the `BigIntegerTest`.

I've tried to follow the existing coding standard as well as I understood it and documented everything like the existing methods.

It would be great if (in case everything is alright) you could merge and tag this addition!