### PR TITLE
Adding support for environments that have a system locales with different decimal separator

### DIFF
--- a/src/BigNumber.php
+++ b/src/BigNumber.php
@@ -24,7 +24,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
         '(?<integral>[\-\+]?[0-9]+)' .
         '(?:' .
             '(?:' .
-                '(?:\.(?<fractional>[0-9]+))?' .
+                '(?:\%s(?<fractional>[0-9]+))?' .
                 '(?:[eE](?<exponent>[\-\+]?[0-9]+))?' .
             ')' . '|' . '(?:' .
                 '(?:\/(?<denominator>[0-9]+))?' .
@@ -63,7 +63,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
 
         $value = (string) $value;
 
-        if (\preg_match(self::PARSE_REGEXP, $value, $matches) !== 1) {
+        if (\preg_match(self::getParseRegexp(), $value, $matches) !== 1) {
             throw new NumberFormatException(\sprintf('The given value "%s" does not represent a valid number.', $value));
         }
 
@@ -99,6 +99,16 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
         $integral = self::cleanUp($matches['integral']);
 
         return new BigInteger($integral);
+    }
+
+    /**
+     * @return string
+     */
+    private static function getParseRegexp() : string
+    {
+        $localeData = localeconv();
+
+        return sprintf(self::PARSE_REGEXP, $localeData['decimal_point']);
     }
 
     /**

--- a/src/BigNumber.php
+++ b/src/BigNumber.php
@@ -61,7 +61,13 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
             return new BigInteger((string) $value);
         }
 
-        $value = self::convertToString($value);
+        if (is_float($value)) {
+            $locData = localeconv();
+
+            $value = str_replace([$locData['thousands_sep'], $locData['decimal_point']], ['', '.'], (string) $value);
+        } else {
+            $value = (string) $value;
+        }
 
         if (\preg_match(self::PARSE_REGEXP, $value, $matches) !== 1) {
             throw new NumberFormatException(\sprintf('The given value "%s" does not represent a valid number.', $value));
@@ -99,17 +105,6 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
         $integral = self::cleanUp($matches['integral']);
 
         return new BigInteger($integral);
-    }
-
-    /**
-     * @param mixed $value
-     * @return string
-     */
-    private static function convertToString($value): string
-    {
-        $localeData = localeconv();
-
-        return str_replace([$localeData['thousands_sep'], $localeData['decimal_point']], ['', '.'], (string) $value);
     }
 
     /**

--- a/src/BigNumber.php
+++ b/src/BigNumber.php
@@ -24,7 +24,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
         '(?<integral>[\-\+]?[0-9]+)' .
         '(?:' .
             '(?:' .
-                '(?:\%s(?<fractional>[0-9]+))?' .
+                '(?:\.(?<fractional>[0-9]+))?' .
                 '(?:[eE](?<exponent>[\-\+]?[0-9]+))?' .
             ')' . '|' . '(?:' .
                 '(?:\/(?<denominator>[0-9]+))?' .
@@ -61,9 +61,9 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
             return new BigInteger((string) $value);
         }
 
-        $value = (string) $value;
+        $value = self::convertToString($value);
 
-        if (\preg_match(self::getParseRegexp(), $value, $matches) !== 1) {
+        if (\preg_match(self::PARSE_REGEXP, $value, $matches) !== 1) {
             throw new NumberFormatException(\sprintf('The given value "%s" does not represent a valid number.', $value));
         }
 
@@ -102,13 +102,14 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
     }
 
     /**
+     * @param mixed $value
      * @return string
      */
-    private static function getParseRegexp() : string
+    private static function convertToString($value): string
     {
         $localeData = localeconv();
 
-        return sprintf(self::PARSE_REGEXP, $localeData['decimal_point']);
+        return str_replace([$localeData['thousands_sep'], $localeData['decimal_point']], ['', '.'], (string) $value);
     }
 
     /**

--- a/tests/BigDecimalTest.php
+++ b/tests/BigDecimalTest.php
@@ -170,11 +170,12 @@ class BigDecimalTest extends AbstractTestCase
      */
     public function testOfValueInDifferentLocales(string $locale): void
     {
-        setlocale(LC_ALL, $locale);
+        $originalLocale = setlocale(LC_NUMERIC, '0');
+        setlocale(LC_NUMERIC, $locale);
 
         $this->assertEquals(2.5, BigDecimal::of(5/2)->toFloat());
 
-        setlocale(LC_ALL, '');
+        setlocale(LC_NUMERIC, $originalLocale);
     }
 
     /**

--- a/tests/BigDecimalTest.php
+++ b/tests/BigDecimalTest.php
@@ -164,6 +164,29 @@ class BigDecimalTest extends AbstractTestCase
     }
 
     /**
+     * @dataProvider providerOfLocales
+     *
+     * @param string $locale
+     */
+    public function testOfValueInDifferentLocales(string $locale): void
+    {
+        setlocale(LC_ALL, $locale);
+
+        $this->assertEquals(2.5, BigDecimal::of(5/2)->toFloat());
+    }
+
+    /**
+     * @return array
+     */
+    public function providerOfLocales(): array
+    {
+        return [
+            ['en_US.UTF-8'],
+            ['de_DE.UTF-8'],
+        ];
+    }
+
+    /**
      * @dataProvider providerOfInvalidValueThrowsException
      * @expectedException \Brick\Math\Exception\NumberFormatException
      *

--- a/tests/BigDecimalTest.php
+++ b/tests/BigDecimalTest.php
@@ -173,6 +173,8 @@ class BigDecimalTest extends AbstractTestCase
         setlocale(LC_ALL, $locale);
 
         $this->assertEquals(2.5, BigDecimal::of(5/2)->toFloat());
+
+        setlocale(LC_ALL, '');
     }
 
     /**


### PR DESCRIPTION
|Q|A|
| - | - |
|Branch?|master|
|Bug fix?|yes|
|New feature?|no|
|BC breaks?|no|
|Tests pass?|yes|

STR:
1. environment must have locale with decimal separator different from `.` (for example `de_DE.UTF-8`) or locale set by terminal variable like `export LC_ALL=de_DE.UTF-8`
2. run any code which do calculations with float values and try to convert value to brick/math type

For example:
```
$decimal = \Brick\Math\BigDecimal::of(5/2);
```

It will not give an error if locale is equal to `eu_US`. But if locale is equal to `de_DE` then there will be an error `Brick\Math\Exception\NumberFormatException : The given value "2,5" does not represent a valid number.`.
It happened because in this environment PHP will use `,` as decimal separator and `::of()` method must be sensitive to it.

It can also happen when using Doctrine and convert float values from DB to brick/math type.