### PR TITLE
Psalm support (+general PHPDoc fixes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4
+  # 7.4 is included in the matrix below
 
 env:
   - CALCULATOR=GMP
@@ -32,8 +32,14 @@ jobs:
   include:
     - stage: Smoke Testing
       php: 7.4
-      env: COVERAGE=yes
-    - stage: Smoke Testing
-      php: 7.4
       env: Psalm
       script: vendor/bin/psalm --show-info=false --no-progress
+    - stage: Smoke Testing
+      php: 7.4
+      env: CALCULATOR=GMP COVERAGE=yes
+    - stage: Smoke Testing
+      php: 7.4
+      env: CALCULATOR=BCMath COVERAGE=yes
+    - stage: Smoke Testing
+      php: 7.4
+      env: CALCULATOR=Native COVERAGE=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 stages:
   - Smoke Testing
   - Test
+  - Test (with coverage)
 
 php:
   # 7.1 is included in the matrix below, with coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ env:
   - CALCULATOR=Native
 
 before_script:
+  - |
+    if [ "x$COVERAGE" != "xyes" ]; then
+      phpenv config-rm xdebug.ini
+    fi
   - composer install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ stages:
   - Test
 
 php:
-  - 7.1
+  # 7.1 is included in the matrix below, with coverage
   - 7.2
   - 7.3
-  # 7.4 is included in the matrix below
+  # 7.4 is included in the matrix below, as base version for smoke testing
 
 env:
   - CALCULATOR=GMP
@@ -44,10 +44,19 @@ jobs:
       script: vendor/bin/psalm --show-info=false --no-progress
     - stage: Smoke Testing
       php: 7.4
+      env: CALCULATOR=GMP
+    - stage: Smoke Testing
+      php: 7.4
+      env: CALCULATOR=BCMath
+    - stage: Smoke Testing
+      php: 7.4
+      env: CALCULATOR=Native
+    - stage: Tests
+      php: 7.1
       env: CALCULATOR=GMP COVERAGE=yes
-    - stage: Smoke Testing
-      php: 7.4
+    - stage: Tests
+      php: 7.1
       env: CALCULATOR=BCMath COVERAGE=yes
-    - stage: Smoke Testing
-      php: 7.4
+    - stage: Tests
+      php: 7.1
       env: CALCULATOR=Native COVERAGE=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+stages:
+  - Smoke Testing
+  - Test
+
 php:
   - 7.1
   - 7.2
@@ -36,7 +40,7 @@ jobs:
   include:
     - stage: Smoke Testing
       php: 7.4
-      env: Psalm
+      name: Psalm
       script: vendor/bin/psalm --show-info=false --no-progress
     - stage: Smoke Testing
       php: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_script:
 script:
   - mkdir -p build/logs
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  - vendor/bin/psalm --show-info=false --no-progress
 
 after_script:
   - vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,25 @@ before_script:
   - composer install
 
 script:
-  - mkdir -p build/logs
-  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-  - vendor/bin/psalm --show-info=false --no-progress
+  - |
+    if [ "x$COVERAGE" == "xyes" ]; then
+      mkdir -p build/logs && vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+    else
+      vendor/bin/phpunit
+    fi
 
 after_script:
-  - vendor/bin/php-coveralls -v
+  - |
+    if [ "x$COVERAGE" == "xyes" ]; then
+      vendor/bin/php-coveralls -v
+    fi
+
+jobs:
+  include:
+    - stage: Smoke Testing
+      php: 7.4
+      env: COVERAGE=yes
+    - stage: Smoke Testing
+      php: 7.4
+      env: Psalm
+      script: vendor/bin/psalm --show-info=false --no-progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,12 @@ jobs:
     - stage: Smoke Testing
       php: 7.4
       env: CALCULATOR=Native
-    - stage: Tests
+    - stage: Test (with coverage)
       php: 7.1
       env: CALCULATOR=GMP COVERAGE=yes
-    - stage: Tests
+    - stage: Test (with coverage)
       php: 7.1
       env: CALCULATOR=BCMath COVERAGE=yes
-    - stage: Tests
+    - stage: Test (with coverage)
       php: 7.1
       env: CALCULATOR=Native COVERAGE=yes

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "7.*",
-        "php-coveralls/php-coveralls": "2.*"
+        "php-coveralls/php-coveralls": "2.*",
+        "vimeo/psalm": "3.*"
     },
     "autoload": {
         "psr-4": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.8.2@90d6b73fd8062432030ef39b7b6694b3902daa31">
   <file src="src/Internal/Calculator/BcMathCalculator.php">
-    <InvalidNullableReturnType occurrences="2">
+    <InvalidNullableReturnType occurrences="3">
+      <code>string</code>
       <code>string</code>
       <code>string</code>
     </InvalidNullableReturnType>
@@ -11,9 +12,10 @@
     <InvalidReturnType occurrences="1">
       <code>array</code>
     </InvalidReturnType>
-    <NullableReturnStatement occurrences="2">
+    <NullableReturnStatement occurrences="3">
       <code>\bcdiv($a, $b, 0)</code>
       <code>\bcmod($a, $b)</code>
+      <code>\bcpowmod($base, $exp, $mod, 0)</code>
     </NullableReturnStatement>
   </file>
   <file src="src/Internal/Calculator/NativeCalculator.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="dev-master@7a65eb1da9caeb4d2657c2c08f4ed998dd0b2764">
+  <file src="src/Internal/Calculator/BcMathCalculator.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>[$q, $r]</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>array</code>
+    </InvalidReturnType>
+  </file>
+  <file src="src/Internal/Calculator/NativeCalculator.php">
+    <InvalidOperand occurrences="6">
+      <code>$a</code>
+      <code>$a</code>
+      <code>$a</code>
+      <code>$b</code>
+      <code>$blockA</code>
+      <code>$blockA</code>
+    </InvalidOperand>
+    <LoopInvalidation occurrences="4">
+      <code>$i</code>
+      <code>$i</code>
+      <code>$i</code>
+      <code>$j</code>
+    </LoopInvalidation>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$e / 2</code>
+    </PossiblyInvalidArgument>
+  </file>
+</files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,12 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@7a65eb1da9caeb4d2657c2c08f4ed998dd0b2764">
+<files psalm-version="3.8.2@90d6b73fd8062432030ef39b7b6694b3902daa31">
   <file src="src/Internal/Calculator/BcMathCalculator.php">
+    <InvalidNullableReturnType occurrences="2">
+      <code>string</code>
+      <code>string</code>
+    </InvalidNullableReturnType>
     <InvalidReturnStatement occurrences="1">
       <code>[$q, $r]</code>
     </InvalidReturnStatement>
     <InvalidReturnType occurrences="1">
       <code>array</code>
     </InvalidReturnType>
+    <NullableReturnStatement occurrences="2">
+      <code>\bcdiv($a, $b, 0)</code>
+      <code>\bcmod($a, $b)</code>
+    </NullableReturnStatement>
   </file>
   <file src="src/Internal/Calculator/NativeCalculator.php">
     <InvalidOperand occurrences="6">

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+
+        <DeprecatedMethod errorLevel="info" />
+        <DeprecatedProperty errorLevel="info" />
+        <DeprecatedClass errorLevel="info" />
+        <DeprecatedConstant errorLevel="info" />
+        <DeprecatedFunction errorLevel="info" />
+        <DeprecatedInterface errorLevel="info" />
+        <DeprecatedTrait errorLevel="info" />
+
+        <InternalMethod errorLevel="info" />
+        <InternalProperty errorLevel="info" />
+        <InternalClass errorLevel="info" />
+
+        <MissingClosureReturnType errorLevel="info" />
+        <MissingReturnType errorLevel="info" />
+        <MissingPropertyType errorLevel="info" />
+        <InvalidDocblock errorLevel="info" />
+        <MisplacedRequiredParam errorLevel="info" />
+
+        <PropertyNotSetInConstructor errorLevel="info" />
+        <MissingConstructor errorLevel="info" />
+        <MissingClosureParamType errorLevel="info" />
+        <MissingParamType errorLevel="info" />
+
+        <RedundantCondition errorLevel="info" />
+
+        <DocblockTypeContradiction errorLevel="info" />
+        <RedundantConditionGivenDocblockType errorLevel="info" />
+
+        <UnresolvableInclude errorLevel="info" />
+
+        <RawObjectIteration errorLevel="info" />
+
+        <InvalidStringClass errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -770,11 +770,11 @@ final class BigDecimal extends BigNumber
     /**
      * Puts the internal values of the given decimal numbers on the same scale.
      *
-     * @param BigDecimal  $x The first decimal number.
-     * @param BigDecimal  $y The second decimal number.
-     * @param string|null $a A variable to store the scaled integer value of $x.
+     * @param BigDecimal $x The first decimal number.
+     * @param BigDecimal $y The second decimal number.
+     * @param string     $a A variable to store the scaled integer value of $x.
      * @param-out string
-     * @param string|null $b A variable to store the scaled integer value of $y.
+     * @param string     $b A variable to store the scaled integer value of $y.
      * @param-out string
      *
      * @return void

--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -49,7 +49,7 @@ final class BigDecimal extends BigNumber
     /**
      * Creates a BigDecimal of the given value.
      *
-     * @param BigNumber|number|string $value
+     * @param BigNumber|int|float|string $value
      *
      * @return BigDecimal
      *
@@ -65,7 +65,7 @@ final class BigDecimal extends BigNumber
      *
      * Example: `(12345, 3)` will result in the BigDecimal `12.345`.
      *
-     * @param BigNumber|number|string $value The unscaled value. Must be convertible to a BigInteger.
+     * @param BigNumber|int|float|string $value The unscaled value. Must be convertible to a BigInteger.
      * @param int                     $scale The scale of the number, positive or zero.
      *
      * @return BigDecimal
@@ -134,7 +134,7 @@ final class BigDecimal extends BigNumber
      *
      * The result has a scale of `max($this->scale, $that->scale)`.
      *
-     * @param BigNumber|number|string $that The number to add. Must be convertible to a BigDecimal.
+     * @param BigNumber|int|float|string $that The number to add. Must be convertible to a BigDecimal.
      *
      * @return BigDecimal The result.
      *
@@ -165,7 +165,7 @@ final class BigDecimal extends BigNumber
      *
      * The result has a scale of `max($this->scale, $that->scale)`.
      *
-     * @param BigNumber|number|string $that The number to subtract. Must be convertible to a BigDecimal.
+     * @param BigNumber|int|float|string $that The number to subtract. Must be convertible to a BigDecimal.
      *
      * @return BigDecimal The result.
      *
@@ -192,7 +192,7 @@ final class BigDecimal extends BigNumber
      *
      * The result has a scale of `$this->scale + $that->scale`.
      *
-     * @param BigNumber|number|string $that The multiplier. Must be convertible to a BigDecimal.
+     * @param BigNumber|int|float|string $that The multiplier. Must be convertible to a BigDecimal.
      *
      * @return BigDecimal The result.
      *
@@ -219,7 +219,7 @@ final class BigDecimal extends BigNumber
     /**
      * Returns the result of the division of this number by the given one, at the given scale.
      *
-     * @param BigNumber|number|string $that         The divisor.
+     * @param BigNumber|int|float|string $that         The divisor.
      * @param int|null                $scale        The desired scale, or null to use the scale of this number.
      * @param int                     $roundingMode An optional rounding mode.
      *
@@ -259,7 +259,7 @@ final class BigDecimal extends BigNumber
      *
      * The scale of the result is automatically calculated to fit all the fraction digits.
      *
-     * @param BigNumber|number|string $that The divisor. Must be convertible to a BigDecimal.
+     * @param BigNumber|int|float|string $that The divisor. Must be convertible to a BigDecimal.
      *
      * @return BigDecimal The result.
      *
@@ -334,7 +334,7 @@ final class BigDecimal extends BigNumber
      *
      * The quotient has a scale of `0`.
      *
-     * @param BigNumber|number|string $that The divisor. Must be convertible to a BigDecimal.
+     * @param BigNumber|int|float|string $that The divisor. Must be convertible to a BigDecimal.
      *
      * @return BigDecimal The quotient.
      *
@@ -361,7 +361,7 @@ final class BigDecimal extends BigNumber
      *
      * The remainder has a scale of `max($this->scale, $that->scale)`.
      *
-     * @param BigNumber|number|string $that The divisor. Must be convertible to a BigDecimal.
+     * @param BigNumber|int|float|string $that The divisor. Must be convertible to a BigDecimal.
      *
      * @return BigDecimal The remainder.
      *
@@ -390,7 +390,7 @@ final class BigDecimal extends BigNumber
      *
      * The quotient has a scale of `0`, and the remainder has a scale of `max($this->scale, $that->scale)`.
      *
-     * @param BigNumber|number|string $that The divisor. Must be convertible to a BigDecimal.
+     * @param BigNumber|int|float|string $that The divisor. Must be convertible to a BigDecimal.
      *
      * @return BigDecimal[] An array containing the quotient and the remainder.
      *

--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -770,12 +770,12 @@ final class BigDecimal extends BigNumber
     /**
      * Puts the internal values of the given decimal numbers on the same scale.
      *
-     * @param BigDecimal $x The first decimal number.
-     * @param BigDecimal $y The second decimal number.
-     * @param string     $a A variable to store the scaled integer value of $x.
-     * @param-out string
-     * @param string     $b A variable to store the scaled integer value of $y.
-     * @param-out string
+     * @param BigDecimal  $x The first decimal number.
+     * @param BigDecimal  $y The second decimal number.
+     * @param string|null $a A variable to store the scaled integer value of $x.
+     * @param-out string  $a
+     * @param string|null $b A variable to store the scaled integer value of $y.
+     * @param-out string  $b
      *
      * @return void
      */

--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -770,12 +770,12 @@ final class BigDecimal extends BigNumber
     /**
      * Puts the internal values of the given decimal numbers on the same scale.
      *
-     * @param BigDecimal  $x The first decimal number.
-     * @param BigDecimal  $y The second decimal number.
-     * @param string|null $a A variable to store the scaled integer value of $x.
-     * @param-out string  $a
-     * @param string|null $b A variable to store the scaled integer value of $y.
-     * @param-out string  $b
+     * @param BigDecimal $x The first decimal number.
+     * @param BigDecimal $y The second decimal number.
+     * @param null       $a A variable to store the scaled integer value of $x.
+     * @param-out string $a
+     * @param null       $b A variable to store the scaled integer value of $y.
+     * @param-out string $b
      *
      * @return void
      */

--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -770,10 +770,12 @@ final class BigDecimal extends BigNumber
     /**
      * Puts the internal values of the given decimal numbers on the same scale.
      *
-     * @param BigDecimal $x The first decimal number.
-     * @param BigDecimal $y The second decimal number.
-     * @param string     $a A variable to store the scaled integer value of $x.
-     * @param string     $b A variable to store the scaled integer value of $y.
+     * @param BigDecimal  $x The first decimal number.
+     * @param BigDecimal  $y The second decimal number.
+     * @param string|null $a A variable to store the scaled integer value of $x.
+     * @param-out string
+     * @param string|null $b A variable to store the scaled integer value of $y.
+     * @param-out string
      *
      * @return void
      */

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -42,7 +42,7 @@ final class BigInteger extends BigNumber
     /**
      * Creates a BigInteger of the given value.
      *
-     * @param BigNumber|number|string $value
+     * @param BigNumber|int|float|string $value
      *
      * @return BigInteger
      *
@@ -211,7 +211,7 @@ final class BigInteger extends BigNumber
     /**
      * Returns the sum of this number and the given one.
      *
-     * @param BigNumber|number|string $that The number to add. Must be convertible to a BigInteger.
+     * @param BigNumber|int|float|string $that The number to add. Must be convertible to a BigInteger.
      *
      * @return BigInteger The result.
      *
@@ -237,7 +237,7 @@ final class BigInteger extends BigNumber
     /**
      * Returns the difference of this number and the given one.
      *
-     * @param BigNumber|number|string $that The number to subtract. Must be convertible to a BigInteger.
+     * @param BigNumber|int|float|string $that The number to subtract. Must be convertible to a BigInteger.
      *
      * @return BigInteger The result.
      *
@@ -259,7 +259,7 @@ final class BigInteger extends BigNumber
     /**
      * Returns the product of this number and the given one.
      *
-     * @param BigNumber|number|string $that The multiplier. Must be convertible to a BigInteger.
+     * @param BigNumber|int|float|string $that The multiplier. Must be convertible to a BigInteger.
      *
      * @return BigInteger The result.
      *
@@ -285,7 +285,7 @@ final class BigInteger extends BigNumber
     /**
      * Returns the result of the division of this number by the given one.
      *
-     * @param BigNumber|number|string $that         The divisor. Must be convertible to a BigInteger.
+     * @param BigNumber|int|float|string $that         The divisor. Must be convertible to a BigInteger.
      * @param int                     $roundingMode An optional rounding mode.
      *
      * @return BigInteger The result.
@@ -343,7 +343,7 @@ final class BigInteger extends BigNumber
     /**
      * Returns the quotient of the division of this number by the given one.
      *
-     * @param BigNumber|number|string $that The divisor. Must be convertible to a BigInteger.
+     * @param BigNumber|int|float|string $that The divisor. Must be convertible to a BigInteger.
      *
      * @return BigInteger
      *
@@ -371,7 +371,7 @@ final class BigInteger extends BigNumber
      *
      * The remainder, when non-zero, has the same sign as the dividend.
      *
-     * @param BigNumber|number|string $that The divisor. Must be convertible to a BigInteger.
+     * @param BigNumber|int|float|string $that The divisor. Must be convertible to a BigInteger.
      *
      * @return BigInteger
      *
@@ -393,7 +393,7 @@ final class BigInteger extends BigNumber
     /**
      * Returns the quotient and remainder of the division of this number by the given one.
      *
-     * @param BigNumber|number|string $that The divisor. Must be convertible to a BigInteger.
+     * @param BigNumber|int|float|string $that The divisor. Must be convertible to a BigInteger.
      *
      * @return BigInteger[] An array containing the quotient and the remainder.
      *
@@ -478,7 +478,7 @@ final class BigInteger extends BigNumber
      *
      * The GCD is always positive, unless both operands are zero, in which case it is zero.
      *
-     * @param BigNumber|number|string $that The operand. Must be convertible to an integer number.
+     * @param BigNumber|int|float|string $that The operand. Must be convertible to an integer number.
      *
      * @return BigInteger
      */
@@ -544,7 +544,7 @@ final class BigInteger extends BigNumber
      *
      * This method returns a negative BigInteger if and only if both operands are negative.
      *
-     * @param BigNumber|number|string $that The operand. Must be convertible to an integer number.
+     * @param BigNumber|int|float|string $that The operand. Must be convertible to an integer number.
      *
      * @return BigInteger
      */
@@ -560,7 +560,7 @@ final class BigInteger extends BigNumber
      *
      * This method returns a negative BigInteger if and only if either of the operands is negative.
      *
-     * @param BigNumber|number|string $that The operand. Must be convertible to an integer number.
+     * @param BigNumber|int|float|string $that The operand. Must be convertible to an integer number.
      *
      * @return BigInteger
      */
@@ -576,7 +576,7 @@ final class BigInteger extends BigNumber
      *
      * This method returns a negative BigInteger if and only if exactly one of the operands is negative.
      *
-     * @param BigNumber|number|string $that The operand. Must be convertible to an integer number.
+     * @param BigNumber|int|float|string $that The operand. Must be convertible to an integer number.
      *
      * @return BigInteger
      */

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -423,7 +423,7 @@ final class BigInteger extends BigNumber
      *
      * The result of the modulo operation, when non-zero, has the same sign as the divisor.
      *
-     * @param BigNumber|number|string $that The divisor. Must be convertible to a BigInteger.
+     * @param BigNumber|int|float|string $that The divisor. Must be convertible to a BigInteger.
      *
      * @return BigInteger
      *
@@ -447,8 +447,8 @@ final class BigInteger extends BigNumber
      *
      * Algorithm from: https://www.geeksforgeeks.org/modular-exponentiation-power-in-modular-arithmetic/
      *
-     * @param BigNumber|number|string $exp The positive exponent.
-     * @param BigNumber|number|string $mod The modulo. Must not be zero.
+     * @param BigNumber|int|float|string $exp The positive exponent.
+     * @param BigNumber|int|float|string $mod The modulo. Must not be zero.
      *
      * @return BigInteger
      *

--- a/src/BigNumber.php
+++ b/src/BigNumber.php
@@ -137,6 +137,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      */
     protected static function create(... $args) : BigNumber
     {
+        /** @psalm-suppress TooManyArguments */
         return new static(... $args);
     }
 

--- a/src/BigNumber.php
+++ b/src/BigNumber.php
@@ -44,7 +44,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      * - strings containing a `.` character or using an exponential notation are returned as BigDecimal
      * - strings containing only digits with an optional leading `+` or `-` sign are returned as BigInteger
      *
-     * @param BigNumber|number|string $value
+     * @param BigNumber|int|float|string $value
      *
      * @return BigNumber
      *
@@ -143,7 +143,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
     /**
      * Returns the minimum of the given values.
      *
-     * @param BigNumber|number|string ...$values The numbers to compare. All the numbers need to be convertible
+     * @param BigNumber|int|float|string ...$values The numbers to compare. All the numbers need to be convertible
      *                                           to an instance of the class this method is called on.
      *
      * @return static The minimum value.
@@ -173,7 +173,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
     /**
      * Returns the maximum of the given values.
      *
-     * @param BigNumber|number|string ...$values The numbers to compare. All the numbers need to be convertible
+     * @param BigNumber|int|float|string ...$values The numbers to compare. All the numbers need to be convertible
      *                                           to an instance of the class this method is called on.
      *
      * @return static The maximum value.
@@ -203,7 +203,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
     /**
      * Returns the sum of the given values.
      *
-     * @param BigNumber|number|string ...$values The numbers to add. All the numbers need to be convertible
+     * @param BigNumber|int|float|string ...$values The numbers to add. All the numbers need to be convertible
      *                                           to an instance of the class this method is called on.
      *
      * @return static The sum.
@@ -300,7 +300,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
     /**
      * Checks if this number is equal to the given one.
      *
-     * @param BigNumber|number|string $that
+     * @param BigNumber|int|float|string $that
      *
      * @return bool
      */
@@ -312,7 +312,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
     /**
      * Checks if this number is strictly lower than the given one.
      *
-     * @param BigNumber|number|string $that
+     * @param BigNumber|int|float|string $that
      *
      * @return bool
      */
@@ -324,7 +324,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
     /**
      * Checks if this number is lower than or equal to the given one.
      *
-     * @param BigNumber|number|string $that
+     * @param BigNumber|int|float|string $that
      *
      * @return bool
      */
@@ -336,7 +336,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
     /**
      * Checks if this number is strictly greater than the given one.
      *
-     * @param BigNumber|number|string $that
+     * @param BigNumber|int|float|string $that
      *
      * @return bool
      */
@@ -348,7 +348,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
     /**
      * Checks if this number is greater than or equal to the given one.
      *
-     * @param BigNumber|number|string $that
+     * @param BigNumber|int|float|string $that
      *
      * @return bool
      */
@@ -417,7 +417,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
     /**
      * Compares this number to the given one.
      *
-     * @param BigNumber|number|string $that
+     * @param BigNumber|int|float|string $that
      *
      * @return int [-1,0,1] If `$this` is lower than, equal to, or greater than `$that`.
      *

--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -59,7 +59,7 @@ final class BigRational extends BigNumber
     /**
      * Creates a BigRational of the given value.
      *
-     * @param BigNumber|number|string $value
+     * @param BigNumber|int|float|string $value
      *
      * @return BigRational
      *
@@ -76,8 +76,8 @@ final class BigRational extends BigNumber
      * If the denominator is negative, the signs of both the numerator and the denominator
      * will be inverted to ensure that the denominator is always positive.
      *
-     * @param BigNumber|number|string $numerator   The numerator. Must be convertible to a BigInteger.
-     * @param BigNumber|number|string $denominator The denominator. Must be convertible to a BigInteger.
+     * @param BigNumber|int|float|string $numerator   The numerator. Must be convertible to a BigInteger.
+     * @param BigNumber|int|float|string $denominator The denominator. Must be convertible to a BigInteger.
      *
      * @return BigRational
      *
@@ -190,7 +190,7 @@ final class BigRational extends BigNumber
     /**
      * Returns the sum of this number and the given one.
      *
-     * @param BigNumber|number|string $that The number to add.
+     * @param BigNumber|int|float|string $that The number to add.
      *
      * @return BigRational The result.
      *
@@ -210,7 +210,7 @@ final class BigRational extends BigNumber
     /**
      * Returns the difference of this number and the given one.
      *
-     * @param BigNumber|number|string $that The number to subtract.
+     * @param BigNumber|int|float|string $that The number to subtract.
      *
      * @return BigRational The result.
      *
@@ -230,7 +230,7 @@ final class BigRational extends BigNumber
     /**
      * Returns the product of this number and the given one.
      *
-     * @param BigNumber|number|string $that The multiplier.
+     * @param BigNumber|int|float|string $that The multiplier.
      *
      * @return BigRational The result.
      *
@@ -249,7 +249,7 @@ final class BigRational extends BigNumber
     /**
      * Returns the result of the division of this number by the given one.
      *
-     * @param BigNumber|number|string $that The divisor.
+     * @param BigNumber|int|float|string $that The divisor.
      *
      * @return BigRational The result.
      *

--- a/src/Internal/Calculator.php
+++ b/src/Internal/Calculator.php
@@ -90,16 +90,16 @@ abstract class Calculator
     /**
      * Extracts the digits and sign of the operands.
      *
-     * @param string      $a    The first operand.
-     * @param string      $b    The second operand.
-     * @param string|null $aDig A variable to store the digits of the first operand.
-     * @param-out string  $aDig
-     * @param string|null $bDig A variable to store the digits of the second operand.
-     * @param-out string  $bDig
-     * @param bool|null   $aNeg A variable to store whether the first operand is negative.
-     * @param-out bool    $aNeg
-     * @param bool|null   $bNeg A variable to store whether the second operand is negative.
-     * @param-out bool    $bNeg
+     * @param string     $a    The first operand.
+     * @param string     $b    The second operand.
+     * @param null       $aDig A variable to store the digits of the first operand.
+     * @param-out string $aDig
+     * @param null       $bDig A variable to store the digits of the second operand.
+     * @param-out string $bDig
+     * @param null       $aNeg A variable to store whether the first operand is negative.
+     * @param-out bool   $aNeg
+     * @param null       $bNeg A variable to store whether the second operand is negative.
+     * @param-out bool   $bNeg
      *
      * @return void
      */

--- a/src/Internal/Calculator.php
+++ b/src/Internal/Calculator.php
@@ -90,16 +90,16 @@ abstract class Calculator
     /**
      * Extracts the digits and sign of the operands.
      *
-     * @param string $a    The first operand.
-     * @param string $b    The second operand.
-     * @param string $aDig A variable to store the digits of the first operand.
-     * @param-out string
-     * @param string $bDig A variable to store the digits of the second operand.
-     * @param-out string
-     * @param bool   $aNeg A variable to store whether the first operand is negative.
-     * @param-out bool
-     * @param bool   $bNeg A variable to store whether the second operand is negative.
-     * @param-out bool
+     * @param string      $a    The first operand.
+     * @param string      $b    The second operand.
+     * @param string|null $aDig A variable to store the digits of the first operand.
+     * @param-out string  $aDig
+     * @param string|null $bDig A variable to store the digits of the second operand.
+     * @param-out string  $bDig
+     * @param bool|null   $aNeg A variable to store whether the first operand is negative.
+     * @param-out bool    $aNeg
+     * @param bool|null   $bNeg A variable to store whether the second operand is negative.
+     * @param-out bool    $bNeg
      *
      * @return void
      */

--- a/src/Internal/Calculator.php
+++ b/src/Internal/Calculator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Brick\Math\Internal;
 
+use Brick\Math\Exception\DivisionByZeroException;
 use Brick\Math\RoundingMode;
 use Brick\Math\Exception\RoundingNecessaryException;
 
@@ -90,12 +91,16 @@ abstract class Calculator
     /**
      * Extracts the digits and sign of the operands.
      *
-     * @param string $a    The first operand.
-     * @param string $b    The second operand.
-     * @param string $aDig A variable to store the digits of the first operand.
-     * @param string $bDig A variable to store the digits of the second operand.
-     * @param bool   $aNeg A variable to store whether the first operand is negative.
-     * @param bool   $bNeg A variable to store whether the second operand is negative.
+     * @param string      $a The first operand.
+     * @param string      $b The second operand.
+     * @param string|null $aDig A variable to store the digits of the first operand.
+     * @param-out string
+     * @param string|null $bDig A variable to store the digits of the second operand.
+     * @param-out string
+     * @param bool|null   $aNeg A variable to store whether the first operand is negative.
+     * @param-out bool
+     * @param bool|null   $bNeg A variable to store whether the second operand is negative.
+     * @param-out bool
      *
      * @return void
      */
@@ -211,6 +216,8 @@ abstract class Calculator
      * @param string $b The divisor, must not be zero.
      *
      * @return string The quotient.
+     *
+     * @throws DivisionByZeroException If the divisor is zero.
      */
     abstract public function divQ(string $a, string $b) : string;
 

--- a/src/Internal/Calculator.php
+++ b/src/Internal/Calculator.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Brick\Math\Internal;
 
-use Brick\Math\Exception\DivisionByZeroException;
-use Brick\Math\RoundingMode;
 use Brick\Math\Exception\RoundingNecessaryException;
+use Brick\Math\RoundingMode;
 
 /**
  * Performs basic operations on arbitrary size integers.
@@ -91,15 +90,15 @@ abstract class Calculator
     /**
      * Extracts the digits and sign of the operands.
      *
-     * @param string      $a The first operand.
-     * @param string      $b The second operand.
-     * @param string|null $aDig A variable to store the digits of the first operand.
+     * @param string $a    The first operand.
+     * @param string $b    The second operand.
+     * @param string $aDig A variable to store the digits of the first operand.
      * @param-out string
-     * @param string|null $bDig A variable to store the digits of the second operand.
+     * @param string $bDig A variable to store the digits of the second operand.
      * @param-out string
-     * @param bool|null   $aNeg A variable to store whether the first operand is negative.
+     * @param bool   $aNeg A variable to store whether the first operand is negative.
      * @param-out bool
-     * @param bool|null   $bNeg A variable to store whether the second operand is negative.
+     * @param bool   $bNeg A variable to store whether the second operand is negative.
      * @param-out bool
      *
      * @return void
@@ -216,8 +215,6 @@ abstract class Calculator
      * @param string $b The divisor, must not be zero.
      *
      * @return string The quotient.
-     *
-     * @throws DivisionByZeroException If the divisor is zero.
      */
     abstract public function divQ(string $a, string $b) : string;
 

--- a/src/Internal/Calculator/BcMathCalculator.php
+++ b/src/Internal/Calculator/BcMathCalculator.php
@@ -56,7 +56,12 @@ class BcMathCalculator extends Calculator
      */
     public function divR(string $a, string $b) : string
     {
-        return \bcmod($a, $b);
+        $result = \bcmod($a, $b);
+        if ($result === null) {
+            throw DivisionByZeroException::divisionByZero();
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Internal/Calculator/BcMathCalculator.php
+++ b/src/Internal/Calculator/BcMathCalculator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Brick\Math\Internal\Calculator;
 
+use Brick\Math\Exception\DivisionByZeroException;
 use Brick\Math\Internal\Calculator;
 
 /**
@@ -42,7 +43,12 @@ class BcMathCalculator extends Calculator
      */
     public function divQ(string $a, string $b) : string
     {
-        return \bcdiv($a, $b, 0);
+        $result = \bcdiv($a, $b, 0);
+        if ($result === null) {
+            throw DivisionByZeroException::divisionByZero();
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Internal/Calculator/BcMathCalculator.php
+++ b/src/Internal/Calculator/BcMathCalculator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Brick\Math\Internal\Calculator;
 
-use Brick\Math\Exception\DivisionByZeroException;
 use Brick\Math\Internal\Calculator;
 
 /**
@@ -43,12 +42,7 @@ class BcMathCalculator extends Calculator
      */
     public function divQ(string $a, string $b) : string
     {
-        $result = \bcdiv($a, $b, 0);
-        if ($result === null) {
-            throw DivisionByZeroException::divisionByZero();
-        }
-
-        return $result;
+        return \bcdiv($a, $b, 0);
     }
 
     /**
@@ -56,12 +50,7 @@ class BcMathCalculator extends Calculator
      */
     public function divR(string $a, string $b) : string
     {
-        $result = \bcmod($a, $b);
-        if ($result === null) {
-            throw DivisionByZeroException::divisionByZero();
-        }
-
-        return $result;
+        return \bcmod($a, $b);
     }
 
     /**


### PR DESCRIPTION
- [x] Psalm config
- [x] Psalm baseline file (if there are still errors after my quick fixes)
- [x] `number` → `int|float` ([PHPDoc standard doesn't contain such a type](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types))
- [x] Psalm's `@param-out`
- [ ] `@psalm-immutable` (for classes) and `@psalm-pure` (for static factory methods) — probably in a separate PR