### PR TITLE
Immutable classes and pure functions/methods annotated

### DIFF
--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -96,7 +96,8 @@ final class BigDecimal extends BigNumber
      */
     public static function zero() : BigDecimal
     {
-        static $zero = null;
+        /** @psalm-suppress ImpureStaticVariable */
+        static $zero;
 
         if ($zero === null) {
             $zero = new BigDecimal('0');
@@ -114,7 +115,8 @@ final class BigDecimal extends BigNumber
      */
     public static function one() : BigDecimal
     {
-        static $one = null;
+        /** @psalm-suppress ImpureStaticVariable */
+        static $one;
 
         if ($one === null) {
             $one = new BigDecimal('1');
@@ -132,7 +134,8 @@ final class BigDecimal extends BigNumber
      */
     public static function ten() : BigDecimal
     {
-        static $ten = null;
+        /** @psalm-suppress ImpureStaticVariable */
+        static $ten;
 
         if ($ten === null) {
             $ten = new BigDecimal('10');

--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -11,6 +11,8 @@ use Brick\Math\Internal\Calculator;
 
 /**
  * Immutable, arbitrary-precision signed decimal numbers.
+ *
+ * @psalm-immutable
  */
 final class BigDecimal extends BigNumber
 {
@@ -54,6 +56,8 @@ final class BigDecimal extends BigNumber
      * @return BigDecimal
      *
      * @throws MathException If the value cannot be converted to a BigDecimal.
+     *
+     * @psalm-pure
      */
     public static function of($value) : BigNumber
     {
@@ -71,6 +75,8 @@ final class BigDecimal extends BigNumber
      * @return BigDecimal
      *
      * @throws \InvalidArgumentException If the scale is negative.
+     *
+     * @psalm-pure
      */
     public static function ofUnscaledValue($value, int $scale = 0) : BigDecimal
     {
@@ -85,6 +91,8 @@ final class BigDecimal extends BigNumber
      * Returns a BigDecimal representing zero, with a scale of zero.
      *
      * @return BigDecimal
+     *
+     * @psalm-pure
      */
     public static function zero() : BigDecimal
     {
@@ -101,6 +109,8 @@ final class BigDecimal extends BigNumber
      * Returns a BigDecimal representing one, with a scale of zero.
      *
      * @return BigDecimal
+     *
+     * @psalm-pure
      */
     public static function one() : BigDecimal
     {
@@ -117,6 +127,8 @@ final class BigDecimal extends BigNumber
      * Returns a BigDecimal representing ten, with a scale of zero.
      *
      * @return BigDecimal
+     *
+     * @psalm-pure
      */
     public static function ten() : BigDecimal
     {

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -16,6 +16,8 @@ use Brick\Math\Internal\Calculator;
  *
  * All methods accepting a number as a parameter accept either a BigInteger instance,
  * an integer, or a string representing an arbitrary size integer.
+ *
+ * @psalm-immutable
  */
 final class BigInteger extends BigNumber
 {
@@ -47,6 +49,8 @@ final class BigInteger extends BigNumber
      * @return BigInteger
      *
      * @throws MathException If the value cannot be converted to a BigInteger.
+     *
+     * @psalm-pure
      */
     public static function of($value) : BigNumber
     {
@@ -71,6 +75,8 @@ final class BigInteger extends BigNumber
      *
      * @throws NumberFormatException     If the number is empty, or contains invalid chars for the given base.
      * @throws \InvalidArgumentException If the base is out of range.
+     *
+     * @psalm-pure
      */
     public static function fromBase(string $number, int $base) : BigInteger
     {
@@ -136,6 +142,8 @@ final class BigInteger extends BigNumber
      *
      * @throws NumberFormatException     If the given number is empty or contains invalid chars for the given alphabet.
      * @throws \InvalidArgumentException If the alphabet does not contain at least 2 chars.
+     *
+     * @psalm-pure
      */
     public static function fromArbitraryBase(string $number, string $alphabet) : BigInteger
     {
@@ -164,6 +172,8 @@ final class BigInteger extends BigNumber
      * Returns a BigInteger representing zero.
      *
      * @return BigInteger
+     *
+     * @psalm-pure
      */
     public static function zero() : BigInteger
     {
@@ -180,6 +190,8 @@ final class BigInteger extends BigNumber
      * Returns a BigInteger representing one.
      *
      * @return BigInteger
+     *
+     * @psalm-pure
      */
     public static function one() : BigInteger
     {
@@ -196,6 +208,8 @@ final class BigInteger extends BigNumber
      * Returns a BigInteger representing ten.
      *
      * @return BigInteger
+     *
+     * @psalm-pure
      */
     public static function ten() : BigInteger
     {

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -177,6 +177,7 @@ final class BigInteger extends BigNumber
      */
     public static function zero() : BigInteger
     {
+        /** @psalm-suppress ImpureStaticVariable */
         static $zero;
 
         if ($zero === null) {
@@ -195,6 +196,7 @@ final class BigInteger extends BigNumber
      */
     public static function one() : BigInteger
     {
+        /** @psalm-suppress ImpureStaticVariable */
         static $one;
 
         if ($one === null) {
@@ -213,6 +215,7 @@ final class BigInteger extends BigNumber
      */
     public static function ten() : BigInteger
     {
+        /** @psalm-suppress ImpureStaticVariable */
         static $ten;
 
         if ($ten === null) {

--- a/src/BigNumber.php
+++ b/src/BigNumber.php
@@ -11,6 +11,8 @@ use Brick\Math\Exception\RoundingNecessaryException;
 
 /**
  * Common interface for arbitrary-precision rational numbers.
+ *
+ * @psalm-immutable
  */
 abstract class BigNumber implements \Serializable, \JsonSerializable
 {
@@ -50,6 +52,8 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      *
      * @throws NumberFormatException   If the format of the number is not valid.
      * @throws DivisionByZeroException If the value represents a rational number with a denominator of zero.
+     *
+     * @psalm-pure
      */
     public static function of($value) : BigNumber
     {
@@ -113,6 +117,9 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      * @param float $float
      *
      * @return string
+     *
+     * @psalm-pure
+     * @psalm-suppress ImpureFunctionCall
      */
     private static function floatToString(float $float) : string
     {
@@ -134,6 +141,8 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      * @param mixed ...$args The arguments to the constructor.
      *
      * @return static
+     *
+     * @psalm-pure
      */
     protected static function create(... $args) : BigNumber
     {
@@ -151,6 +160,8 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      *
      * @throws \InvalidArgumentException If no values are given.
      * @throws MathException             If an argument is not valid.
+     *
+     * @psalm-pure
      */
     public static function min(...$values) : BigNumber
     {
@@ -181,6 +192,8 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      *
      * @throws \InvalidArgumentException If no values are given.
      * @throws MathException             If an argument is not valid.
+     *
+     * @psalm-pure
      */
     public static function max(...$values) : BigNumber
     {
@@ -211,6 +224,8 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      *
      * @throws \InvalidArgumentException If no values are given.
      * @throws MathException             If an argument is not valid.
+     *
+     * @psalm-pure
      */
     public static function sum(...$values) : BigNumber
     {
@@ -246,6 +261,8 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      * @param BigNumber $b
      *
      * @return BigNumber
+     *
+     * @psalm-pure
      */
     private static function add(BigNumber $a, BigNumber $b) : BigNumber
     {
@@ -276,6 +293,8 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      * @param string $number The number, validated as a non-empty string of digits with optional sign.
      *
      * @return string
+     *
+     * @psalm-pure
      */
     private static function cleanUp(string $number) : string
     {

--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -13,6 +13,8 @@ use Brick\Math\Exception\RoundingNecessaryException;
  * An arbitrarily large rational number.
  *
  * This class is immutable.
+ *
+ * @psalm-immutable
  */
 final class BigRational extends BigNumber
 {
@@ -64,6 +66,8 @@ final class BigRational extends BigNumber
      * @return BigRational
      *
      * @throws MathException If the value cannot be converted to a BigRational.
+     *
+     * @psalm-pure
      */
     public static function of($value) : BigNumber
     {
@@ -84,6 +88,8 @@ final class BigRational extends BigNumber
      * @throws NumberFormatException      If an argument does not represent a valid number.
      * @throws RoundingNecessaryException If an argument represents a non-integer number.
      * @throws DivisionByZeroException    If the denominator is zero.
+     *
+     * @psalm-pure
      */
     public static function nd($numerator, $denominator) : BigRational
     {
@@ -97,6 +103,8 @@ final class BigRational extends BigNumber
      * Returns a BigRational representing zero.
      *
      * @return BigRational
+     *
+     * @psalm-pure
      */
     public static function zero() : BigRational
     {
@@ -113,6 +121,8 @@ final class BigRational extends BigNumber
      * Returns a BigRational representing one.
      *
      * @return BigRational
+     *
+     * @psalm-pure
      */
     public static function one() : BigRational
     {
@@ -129,6 +139,8 @@ final class BigRational extends BigNumber
      * Returns a BigRational representing ten.
      *
      * @return BigRational
+     *
+     * @psalm-pure
      */
     public static function ten() : BigRational
     {

--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -108,6 +108,7 @@ final class BigRational extends BigNumber
      */
     public static function zero() : BigRational
     {
+        /** @psalm-suppress ImpureStaticVariable */
         static $zero;
 
         if ($zero === null) {
@@ -126,6 +127,7 @@ final class BigRational extends BigNumber
      */
     public static function one() : BigRational
     {
+        /** @psalm-suppress ImpureStaticVariable */
         static $one;
 
         if ($one === null) {
@@ -144,6 +146,7 @@ final class BigRational extends BigNumber
      */
     public static function ten() : BigRational
     {
+        /** @psalm-suppress ImpureStaticVariable */
         static $ten;
 
         if ($ten === null) {

--- a/src/Exception/DivisionByZeroException.php
+++ b/src/Exception/DivisionByZeroException.php
@@ -11,6 +11,8 @@ class DivisionByZeroException extends MathException
 {
     /**
      * @return DivisionByZeroException
+     *
+     * @psalm-pure
      */
     public static function divisionByZero() : DivisionByZeroException
     {
@@ -19,6 +21,8 @@ class DivisionByZeroException extends MathException
 
     /**
      * @return DivisionByZeroException
+     *
+     * @psalm-pure
      */
     public static function denominatorMustNotBeZero() : DivisionByZeroException
     {

--- a/src/Exception/IntegerOverflowException.php
+++ b/src/Exception/IntegerOverflowException.php
@@ -15,6 +15,8 @@ class IntegerOverflowException extends MathException
      * @param BigInteger $value
      *
      * @return IntegerOverflowException
+     *
+     * @psalm-pure
      */
     public static function toIntOverflow(BigInteger $value) : IntegerOverflowException
     {

--- a/src/Exception/NumberFormatException.php
+++ b/src/Exception/NumberFormatException.php
@@ -6,8 +6,6 @@ namespace Brick\Math\Exception;
 
 /**
  * Exception thrown when attempting to create a number from a string with an invalid format.
- *
- * @psalm-immutable
  */
 class NumberFormatException extends MathException
 {

--- a/src/Exception/NumberFormatException.php
+++ b/src/Exception/NumberFormatException.php
@@ -6,6 +6,8 @@ namespace Brick\Math\Exception;
 
 /**
  * Exception thrown when attempting to create a number from a string with an invalid format.
+ *
+ * @psalm-immutable
  */
 class NumberFormatException extends MathException
 {
@@ -13,6 +15,8 @@ class NumberFormatException extends MathException
      * @param string $char The failing character.
      *
      * @return NumberFormatException
+     *
+     * @psalm-pure
      */
     public static function charNotInAlphabet(string $char) : self
     {

--- a/src/Exception/RoundingNecessaryException.php
+++ b/src/Exception/RoundingNecessaryException.php
@@ -11,6 +11,8 @@ class RoundingNecessaryException extends MathException
 {
     /**
      * @return RoundingNecessaryException
+     *
+     * @psalm-pure
      */
     public static function roundingNecessary() : RoundingNecessaryException
     {

--- a/src/Internal/Calculator.php
+++ b/src/Internal/Calculator.php
@@ -17,6 +17,8 @@ use Brick\Math\RoundingMode;
  * All methods must return strings respecting this format, unless specified otherwise.
  *
  * @internal
+ *
+ * @psalm-immutable
  */
 abstract class Calculator
 {
@@ -57,10 +59,13 @@ abstract class Calculator
      * If none has been explicitly set, the fastest available implementation will be returned.
      *
      * @return Calculator
+     *
+     * @psalm-pure
      */
     final public static function get() : Calculator
     {
         if (self::$instance === null) {
+            /** @psalm-suppress ImpureMethodCall */
             self::$instance = self::detect();
         }
 

--- a/src/Internal/Calculator/BcMathCalculator.php
+++ b/src/Internal/Calculator/BcMathCalculator.php
@@ -10,6 +10,8 @@ use Brick\Math\Internal\Calculator;
  * Calculator implementation built around the bcmath library.
  *
  * @internal
+ *
+ * @psalm-immutable
  */
 class BcMathCalculator extends Calculator
 {

--- a/src/Internal/Calculator/GmpCalculator.php
+++ b/src/Internal/Calculator/GmpCalculator.php
@@ -10,6 +10,8 @@ use Brick\Math\Internal\Calculator;
  * Calculator implementation built around the GMP library.
  *
  * @internal
+ *
+ * @psalm-immutable
  */
 class GmpCalculator extends Calculator
 {

--- a/src/Internal/Calculator/NativeCalculator.php
+++ b/src/Internal/Calculator/NativeCalculator.php
@@ -10,6 +10,8 @@ use Brick\Math\Internal\Calculator;
  * Calculator implementation using only native PHP code.
  *
  * @internal
+ *
+ * @psalm-immutable
  */
 class NativeCalculator extends Calculator
 {


### PR DESCRIPTION
Continuation of #27.

`@psalm-immutable` ensures that no mutations can be introduced in the future changes, while `@psalm-pure` insures no side effects.

This also helps clients that use the library and Psalm, because they can use `@psalm-pure` in their code with `brick/math` without errors (because Psalm knows that static methods here are also pure). 