### PR TITLE
Fixed missing test cases and PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.1"
+        "php": "^7.1|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "7.*",
-        "php-coveralls/php-coveralls": "2.*",
-        "vimeo/psalm": "3.*"
+        "phpunit/phpunit": "^7.5.15|^8.5",
+        "php-coveralls/php-coveralls": "^2.2",
+        "vimeo/psalm": "^3.5"
     },
     "autoload": {
         "psr-4": {

--- a/tests/BigDecimalTest.php
+++ b/tests/BigDecimalTest.php
@@ -205,7 +205,7 @@ class BigDecimalTest extends AbstractTestCase
     /**
      * @dataProvider providerOfInvalidValueThrowsException
      */
-    public function testOfInvalidValueThrowsException(string $value) : void
+    public function testOfInvalidValueThrowsException($value) : void
     {
         $this->expectException(NumberFormatException::class);
         BigDecimal::of($value);
@@ -2047,11 +2047,11 @@ class BigDecimalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a The base number as a string.
-     * @param string $b The number to compare to as a string.
-     * @param int    $c The expected comparison result.
+     * @param string           $a The base number as a string.
+     * @param string|int|float $b The number to compare to.
+     * @param int              $c The comparison result.
      */
-    public function testCompareTo(string $a, string $b, int $c) : void
+    public function testCompareTo(string $a, $b, int $c) : void
     {
         self::assertSame($c, BigDecimal::of($a)->compareTo($b));
     }
@@ -2059,11 +2059,11 @@ class BigDecimalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a The base number as a string.
-     * @param string $b The number to compare to as a string.
-     * @param int    $c The comparison result.
+     * @param string           $a The base number as a string.
+     * @param string|int|float $b The number to compare to.
+     * @param int              $c The comparison result.
      */
-    public function testIsEqualTo(string $a, string $b, int $c) : void
+    public function testIsEqualTo(string $a, $b, int $c) : void
     {
         self::assertSame($c === 0, BigDecimal::of($a)->isEqualTo($b));
     }
@@ -2071,11 +2071,11 @@ class BigDecimalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a The base number as a string.
-     * @param string $b The number to compare to as a string.
-     * @param int    $c The comparison result.
+     * @param string           $a The base number as a string.
+     * @param string|int|float $b The number to compare to.
+     * @param int              $c The comparison result.
      */
-    public function testIsLessThan(string $a, string $b, int $c) : void
+    public function testIsLessThan(string $a, $b, int $c) : void
     {
         self::assertSame($c < 0, BigDecimal::of($a)->isLessThan($b));
     }
@@ -2083,11 +2083,11 @@ class BigDecimalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a The base number as a string.
-     * @param string $b The number to compare to as a string.
-     * @param int    $c The comparison result.
+     * @param string           $a The base number as a string.
+     * @param string|int|float $b The number to compare to.
+     * @param int              $c The comparison result.
      */
-    public function testIsLessThanOrEqualTo(string $a, string $b, int $c) : void
+    public function testIsLessThanOrEqualTo(string $a, $b, int $c) : void
     {
         self::assertSame($c <= 0, BigDecimal::of($a)->isLessThanOrEqualTo($b));
     }
@@ -2095,11 +2095,11 @@ class BigDecimalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a The base number as a string.
-     * @param string $b The number to compare to as a string.
-     * @param int    $c The comparison result.
+     * @param string           $a The base number as a string.
+     * @param string|int|float $b The number to compare to.
+     * @param int              $c The comparison result.
      */
-    public function testIsGreaterThan(string $a, string $b, int $c) : void
+    public function testIsGreaterThan(string $a, $b, int $c) : void
     {
         self::assertSame($c > 0, BigDecimal::of($a)->isGreaterThan($b));
     }
@@ -2107,11 +2107,11 @@ class BigDecimalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a The base number as a string.
-     * @param string $b The number to compare to as a string.
-     * @param int    $c The comparison result.
+     * @param string           $a The base number as a string.
+     * @param string|int|float $b The number to compare to.
+     * @param int              $c The comparison result.
      */
-    public function testIsGreaterThanOrEqualTo(string $a, string $b, int $c) : void
+    public function testIsGreaterThanOrEqualTo(string $a, $b, int $c) : void
     {
         self::assertSame($c >= 0, BigDecimal::of($a)->isGreaterThanOrEqualTo($b));
     }

--- a/tests/BigIntegerTest.php
+++ b/tests/BigIntegerTest.php
@@ -526,11 +526,11 @@ class BigIntegerTest extends AbstractTestCase
     /**
      * @dataProvider providerMultipliedBy
      *
-     * @param string $a The base number.
-     * @param string $b The number to multiply.
-     * @param string $r The expected result.
+     * @param string     $a The base number.
+     * @param string|int $b The number to multiply.
+     * @param string     $r The expected result.
      */
-    public function testMultipliedBy(string $a, string $b, string $r) : void
+    public function testMultipliedBy(string $a, $b, string $r) : void
     {
         self::assertBigIntegerEquals($r, BigInteger::of($a)->multipliedBy($b));
     }
@@ -560,11 +560,11 @@ class BigIntegerTest extends AbstractTestCase
     /**
      * @dataProvider providerDividedBy
      *
-     * @param string $number   The base number.
-     * @param string $divisor  The divisor.
-     * @param string $expected The expected result, or a class name if an exception is expected.
+     * @param string           $number   The base number.
+     * @param string|int|float $divisor  The divisor.
+     * @param string           $expected The expected result, or a class name if an exception is expected.
      */
-    public function testDividedBy(string $number, string $divisor, string $expected) : void
+    public function testDividedBy(string $number, $divisor, string $expected) : void
     {
         $number = BigInteger::of($number);
 

--- a/tests/BigIntegerTest.php
+++ b/tests/BigIntegerTest.php
@@ -1411,7 +1411,7 @@ class BigIntegerTest extends AbstractTestCase
     /**
      * @dataProvider providerPowerModNegativeThrowsException
      */
-    public function testPowerModNegativeThrowsException(string $base, string $exp, string $mod) : void
+    public function testPowerModNegativeThrowsException(int $base, int $exp, int $mod) : void
     {
         $this->expectException(NegativeNumberException::class);
         BigInteger::of($base)->powerMod($exp, $mod);

--- a/tests/BigRationalTest.php
+++ b/tests/BigRationalTest.php
@@ -22,10 +22,10 @@ class BigRationalTest extends AbstractTestCase
      *
      * @param string $numerator   The expected numerator.
      * @param string $denominator The expected denominator.
-     * @param string $n           The input numerator.
-     * @param string $d           The input denominator.
+     * @param string|int $n       The input numerator.
+     * @param string|int $d       The input denominator.
      */
-    public function testNd(string $numerator, string $denominator, string $n, string $d) : void
+    public function testNd(string $numerator, string $denominator, $n, $d) : void
     {
         $rational = BigRational::nd($n, $d);
         self::assertBigRationalInternalValues($numerator, $denominator, $rational);
@@ -221,11 +221,11 @@ class BigRationalTest extends AbstractTestCase
     /**
      * @dataProvider providerQuotientAndRemainder
      *
-     * @param string $rational  The rational number to test.
-     * @param string $quotient  The expected quotient.
-     * @param string $remainder The expected remainder.
+     * @param string|int $rational  The rational number to test.
+     * @param string     $quotient  The expected quotient.
+     * @param string     $remainder The expected remainder.
      */
-    public function testQuotientAndRemainder(string $rational, string $quotient, string $remainder) : void
+    public function testQuotientAndRemainder($rational, string $quotient, string $remainder) : void
     {
         $rational = BigRational::of($rational);
 
@@ -251,11 +251,11 @@ class BigRationalTest extends AbstractTestCase
     /**
      * @dataProvider providerPlus
      *
-     * @param string $rational The rational number to test.
-     * @param string $plus     The number to add.
-     * @param string $expected The expected rational number result.
+     * @param string                            $rational The rational number to test.
+     * @param string|int|BigInteger|BigRational $plus     The number to add.
+     * @param string                            $expected The expected rational number result.
      */
-    public function testPlus(string $rational, string $plus, string $expected) : void
+    public function testPlus(string $rational, $plus, string $expected) : void
     {
         self::assertBigRationalEquals($expected, BigRational::of($rational)->plus($plus));
     }
@@ -516,11 +516,11 @@ class BigRationalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a   The first number to compare.
-     * @param string $b   The second number to compare.
-     * @param int    $cmp The comparison value.
+     * @param string     $a   The first number to compare.
+     * @param string|int $b   The second number to compare.
+     * @param int        $cmp The comparison value.
      */
-    public function testCompareTo(string $a, string $b, int $cmp) : void
+    public function testCompareTo(string $a, $b, int $cmp) : void
     {
         self::assertSame($cmp, BigRational::of($a)->compareTo($b));
     }
@@ -528,11 +528,11 @@ class BigRationalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a   The first number to compare.
-     * @param string $b   The second number to compare.
-     * @param int    $cmp The comparison value.
+     * @param string     $a   The first number to compare.
+     * @param string|int $b   The second number to compare.
+     * @param int        $cmp The comparison value.
      */
-    public function testIsEqualTo(string $a, string $b, int $cmp) : void
+    public function testIsEqualTo(string $a, $b, int $cmp) : void
     {
         self::assertSame($cmp === 0, BigRational::of($a)->isEqualTo($b));
     }
@@ -540,11 +540,11 @@ class BigRationalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a   The first number to compare.
-     * @param string $b   The second number to compare.
-     * @param int    $cmp The comparison value.
+     * @param string     $a   The first number to compare.
+     * @param string|int $b   The second number to compare.
+     * @param int        $cmp The comparison value.
      */
-    public function testIsLessThan(string $a, string $b, int $cmp) : void
+    public function testIsLessThan(string $a, $b, int $cmp) : void
     {
         self::assertSame($cmp < 0, BigRational::of($a)->isLessThan($b));
     }
@@ -552,11 +552,11 @@ class BigRationalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a   The first number to compare.
-     * @param string $b   The second number to compare.
-     * @param int    $cmp The comparison value.
+     * @param string     $a   The first number to compare.
+     * @param string|int $b   The second number to compare.
+     * @param int        $cmp The comparison value.
      */
-    public function testIsLessThanOrEqualTo(string $a, string $b, int $cmp) : void
+    public function testIsLessThanOrEqualTo(string $a, $b, int $cmp) : void
     {
         self::assertSame($cmp <= 0, BigRational::of($a)->isLessThanOrEqualTo($b));
     }
@@ -564,11 +564,11 @@ class BigRationalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a   The first number to compare.
-     * @param string $b   The second number to compare.
-     * @param int    $cmp The comparison value.
+     * @param string     $a   The first number to compare.
+     * @param string|int $b   The second number to compare.
+     * @param int        $cmp The comparison value.
      */
-    public function testIsGreaterThan(string $a, string $b, int $cmp) : void
+    public function testIsGreaterThan(string $a, $b, int $cmp) : void
     {
         self::assertSame($cmp > 0, BigRational::of($a)->isGreaterThan($b));
     }
@@ -576,11 +576,11 @@ class BigRationalTest extends AbstractTestCase
     /**
      * @dataProvider providerCompareTo
      *
-     * @param string $a   The first number to compare.
-     * @param string $b   The second number to compare.
-     * @param int    $cmp The comparison value.
+     * @param string     $a   The first number to compare.
+     * @param string|int $b   The second number to compare.
+     * @param int        $cmp The comparison value.
      */
-    public function testIsGreaterThanOrEqualTo(string $a, string $b, int $cmp) : void
+    public function testIsGreaterThanOrEqualTo(string $a, $b, int $cmp) : void
     {
         self::assertSame($cmp >= 0, BigRational::of($a)->isGreaterThanOrEqualTo($b));
     }
@@ -844,10 +844,10 @@ class BigRationalTest extends AbstractTestCase
     /**
      * @dataProvider providerToInt
      *
-     * @param string $rational The rational number to test.
-     * @param int    $integer  The expected integer value.
+     * @param string|int $rational The rational number to test.
+     * @param int        $integer  The expected integer value.
      */
-    public function testToInt(string $rational, int $integer) : void
+    public function testToInt($rational, int $integer) : void
     {
         self::assertSame($integer, BigRational::of($rational)->toInt());
     }


### PR DESCRIPTION
It looks like the tests were incorrectly casting some cases to a string which means the tests were not actually doing what they were meant to. I've fixed this also. NB This was highlighted because PHPUnit calls tests with strict types enabled from v8 upwards.

It's good practice to bounded version constraints (such as on the PHP versions). I've also tweaked the minimum dependency versions so that they work properly on PHP 7.4.