### PR TITLE
Specify decimal amount when converting to float

### DIFF
--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -733,7 +733,7 @@ final class BigDecimal extends BigNumber
         $float = (float) (string) $this;
 
         if ($decimals > 0) {
-            return number_format($float, $decimals);
+            return (float) number_format($float, $decimals);
         }
 
         return $float;

--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -728,9 +728,15 @@ final class BigDecimal extends BigNumber
     /**
      * {@inheritdoc}
      */
-    public function toFloat() : float
+    public function toFloat(int $decimals = 0) : float
     {
-        return (float) (string) $this;
+        $float = (float) (string) $this;
+
+        if ($decimals > 0) {
+            return number_format($float, $decimals);
+        }
+
+        return $float;
     }
 
     /**

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -805,9 +805,15 @@ final class BigInteger extends BigNumber
     /**
      * {@inheritdoc}
      */
-    public function toFloat() : float
+    public function toFloat(int $decimals = 0) : float
     {
-        return (float) $this->value;
+        $float = (float) $this->value;
+
+        if ($decimals > 0) {
+            return number_format($float, $decimals);
+        }
+
+        return $float;
     }
 
     /**

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -810,7 +810,7 @@ final class BigInteger extends BigNumber
         $float = (float) $this->value;
 
         if ($decimals > 0) {
-            return number_format($float, $decimals);
+            return (float) number_format($float, $decimals);
         }
 
         return $float;

--- a/src/BigNumber.php
+++ b/src/BigNumber.php
@@ -506,7 +506,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      *
      * @return float The converted value.
      */
-    abstract public function toFloat(int $decimals = 0) : float
+    abstract public function toFloat(int $decimals = 0) : float;
 
     /**
      * Returns a string representation of this number.

--- a/src/BigNumber.php
+++ b/src/BigNumber.php
@@ -506,7 +506,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
      *
      * @return float The converted value.
      */
-    abstract public function toFloat() : float;
+    abstract public function toFloat(int $decimals = 0) : float
 
     /**
      * Returns a string representation of this number.

--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -422,9 +422,9 @@ final class BigRational extends BigNumber
     /**
      * {@inheritdoc}
      */
-    public function toFloat() : float
+    public function toFloat(int $decimals = 0) : float
     {
-        return $this->numerator->toFloat() / $this->denominator->toFloat();
+        return $this->numerator->toFloat($decimals) / $this->denominator->toFloat($decimals);
     }
 
     /**


### PR DESCRIPTION
I had to compare 2 float values using BigDecimal class, but I was getting an unexpected result because those floats had no decimals:

```php
BigDecimal::of($result1)->toFloat(); // 123.0
BigDecimal::of($result2)->toFloat(); // 123

return $result1 === $result2; // returns false
```

With this solution, specifying the amount of decimals will get expected results

```php
BigDecimal::of($result1)->toFloat(1); // 123.0
BigDecimal::of($result2)->toFloat(1); // 123.0

return $result1 === $result2; // returns true
```
