### PR TITLE
Using assertInstanceOf to assert expected class

### DIFF
--- a/tests/BigNumberTest.php
+++ b/tests/BigNumberTest.php
@@ -28,7 +28,7 @@ class BigNumberTest extends AbstractTestCase
     {
         $sum = BigNumber::sum(...$values);
 
-        self::assertSame($expectedClass, get_class($sum));
+        self::assertInstanceOf($expectedClass, $sum);
         self::assertSame($expectedSum, (string) $sum);
     }
 


### PR DESCRIPTION
# Changed log

- It should use the `assertInstanceOf` to assert actual class instance is same as the expected class instance.