### PR TITLE
Add support for custom object serialization

### DIFF
--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -753,6 +753,40 @@ final class BigDecimal extends BigNumber
     }
 
     /**
+     * This method is required for serializing the object and SHOULD NOT be accessed directly.
+     *
+     * @internal
+     *
+     * @return array{value: string, scale: int}
+     */
+    public function __serialize(): array
+    {
+        return ['value' => $this->value, 'scale' => $this->scale];
+    }
+
+    /**
+     * This method is only here to allow unserializing the object and cannot be accessed directly.
+     *
+     * @internal
+     * @psalm-suppress RedundantPropertyInitializationCheck
+     *
+     * @param array{value: string, scale: int} $data
+     *
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    public function __unserialize(array $data): void
+    {
+        if (isset($this->value)) {
+            throw new \LogicException('__unserialize() is an internal function, it must not be called directly.');
+        }
+
+        $this->value = $data['value'];
+        $this->scale = $data['scale'];
+    }
+
+    /**
      * This method is required by interface Serializable and SHOULD NOT be accessed directly.
      *
      * @internal

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -1117,6 +1117,39 @@ final class BigInteger extends BigNumber
     }
 
     /**
+     * This method is required for serializing the object and SHOULD NOT be accessed directly.
+     *
+     * @internal
+     *
+     * @return array{value: string}
+     */
+    public function __serialize(): array
+    {
+        return ['value' => $this->value];
+    }
+
+    /**
+     * This method is only here to allow unserializing the object and cannot be accessed directly.
+     *
+     * @internal
+     * @psalm-suppress RedundantPropertyInitializationCheck
+     *
+     * @param array{value: string} $data
+     *
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    public function __unserialize(array $data): void
+    {
+        if (isset($this->value)) {
+            throw new \LogicException('__unserialize() is an internal function, it must not be called directly.');
+        }
+
+        $this->value = $data['value'];
+    }
+
+    /**
      * This method is required by interface Serializable and SHOULD NOT be accessed directly.
      *
      * @internal

--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -452,6 +452,40 @@ final class BigRational extends BigNumber
     }
 
     /**
+     * This method is required for serializing the object and SHOULD NOT be accessed directly.
+     *
+     * @internal
+     *
+     * @return array{numerator: \Brick\Math\BigInteger, denominator: \Brick\Math\BigInteger}
+     */
+    public function __serialize(): array
+    {
+        return ['numerator' => $this->numerator, 'denominator' => $this->denominator];
+    }
+
+    /**
+     * This method is only here to allow unserializing the object and cannot be accessed directly.
+     *
+     * @internal
+     * @psalm-suppress RedundantPropertyInitializationCheck
+     *
+     * @param array{numerator: \Brick\Math\BigInteger, denominator: \Brick\Math\BigInteger} $data
+     *
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    public function __unserialize(array $data): void
+    {
+        if (isset($this->value)) {
+            throw new \LogicException('__unserialize() is an internal function, it must not be called directly.');
+        }
+
+        $this->numerator = $data['numerator'];
+        $this->denominator = $data['denominator'];
+    }
+
+    /**
      * This method is required by interface Serializable and SHOULD NOT be accessed directly.
      *
      * @internal

--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -477,7 +477,7 @@ final class BigRational extends BigNumber
      */
     public function __unserialize(array $data): void
     {
-        if (isset($this->value)) {
+        if (isset($this->numerator)) {
             throw new \LogicException('__unserialize() is an internal function, it must not be called directly.');
         }
 


### PR DESCRIPTION
This adds support for the [custom object serialization](https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.standard.magic-serialize) feature added in PHP 7.4. This is needed to suppress deprecation warnings in PHP 8.1 since the `Serializable` interface is now deprecated.