### PR TITLE
Call simplify before toFloat conversion

### DIFF
--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -429,7 +429,8 @@ final class BigRational extends BigNumber
      */
     public function toFloat() : float
     {
-        return $this->numerator->toFloat() / $this->denominator->toFloat();
+        $simplified = $this->simplified();
+        return $simplified->numerator->toFloat() / $simplified->denominator->toFloat();
     }
 
     /**

--- a/tests/BigRationalTest.php
+++ b/tests/BigRationalTest.php
@@ -916,12 +916,8 @@ class BigRationalTest extends AbstractTestCase
 
     public function testToFloatConversionPerformsSimplificationToPreventOverflow() : void
     {
-        $val = BigRational::of(1);
-        $factor = 10000;
-
-        for ($i = 0; $i < 1000; ++$i) {
-            $val = $val->multipliedBy($factor)->dividedBy($factor);
-        }
+        $int = BigInteger::of('1e4000');
+        $val = BigRational::nd($int, $int);
 
         self::assertInfinite($val->getNumerator()->toFloat());
         // Assert that simplification is required and the test would fail without it

--- a/tests/BigRationalTest.php
+++ b/tests/BigRationalTest.php
@@ -892,6 +892,42 @@ class BigRationalTest extends AbstractTestCase
         ];
     }
 
+    public function testIdentityOperationResultsInDifferentToFloatValueWithoutSimplification() : void
+    {
+        $expectedValue = 11.46;
+        $conversionFactor = BigRational::of('0.45359237');
+        $value = BigRational::of($expectedValue);
+
+        $identicalValueAfterMathOperations = $value->multipliedBy($conversionFactor)
+            ->dividedBy($conversionFactor)
+            ->multipliedBy($conversionFactor)
+            ->dividedBy($conversionFactor)
+            ->multipliedBy($conversionFactor)
+            ->dividedBy($conversionFactor);
+
+        self::assertSame($expectedValue, $identicalValueAfterMathOperations->toFloat());
+
+        // Assert that simplification is required and the test would fail without it
+        self::assertNotSame(
+            $expectedValue,
+            $identicalValueAfterMathOperations->getNumerator()->toFloat() / $identicalValueAfterMathOperations->getDenominator()->toFloat(),
+        );
+    }
+
+    public function testToFloatConversionPerformsSimplificationToPreventOverflow() : void
+    {
+        $val = BigRational::of(1);
+        $factor = 10000;
+
+        for ($i = 0; $i < 1000; ++$i) {
+            $val = $val->multipliedBy($factor)->dividedBy($factor);
+        }
+
+        self::assertInfinite($val->getNumerator()->toFloat());
+        // Assert that simplification is required and the test would fail without it
+        self::assertSame(1.0, $val->toFloat());
+    }
+
     /**
      * @dataProvider providerToFloat
      *


### PR DESCRIPTION
Calling `$rationalNumber->toFloat()` may result in a huge loss of precision due to the limits of floating point representation which can be prevented (not every time, but in a lot of real-world cases) by calling `->simplified()` first.

~~Such loss of precision caused by a very large nominator or denominator may be actually (and unexpectedly) way larger than if regular 64bit floating numbers were used for all math operations instead (assuming some real-world numeric range).~~ Even with regular numeric range, float overflow may easily occur.

We ran into this issue in production quite a few times in the legacy parts where we did not migrate yet to using BigRational and we perform the float conversion.

Therefore I'd like to suggest calling `->simplify` every time before `->toFloat()` conversion. I understand that the operation does not come for free, I'd like to hear your opinion :)

Thank you for this otherwise excellent library!