### PR TITLE
BigNumber::of performance update

### DIFF
--- a/src/BigNumber.php
+++ b/src/BigNumber.php
@@ -146,7 +146,11 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
         }
     }
 
-    protected static function throwException(string $value) : NumberFormatException {
+    /**
+     * Throws a NumberFormatException for the given value.
+     * @psalm-pure
+     */
+    protected static function throwException(string $value) : void {
         throw new NumberFormatException(\sprintf(
             'The given value "%s" does not represent a valid number.',
             $value

--- a/src/BigNumber.php
+++ b/src/BigNumber.php
@@ -146,7 +146,7 @@ abstract class BigNumber implements \Serializable, \JsonSerializable
         }
     }
 
-    protected static function throwException($value) {
+    protected static function throwException(string $value) : NumberFormatException {
         throw new NumberFormatException(\sprintf(
             'The given value "%s" does not represent a valid number.',
             $value


### PR DESCRIPTION
1. Split regex for Rational and Numerical
2. Exception method is static to the class instead of being created dynamically for each call to BigNumber::of
3. Added flag to pregMatch to return no matches as NULL instead of manipulating empty string and converting it to null
4. leanCleanup introduced as there was a concatenation of sign to pass to the cleanup function which then removes the sign from the string