### PR TITLE
feat(#84): add ability to optionally apply abs and negated functions inline

### DIFF
--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -661,10 +661,10 @@ final class BigDecimal extends BigNumber
         return (float) (string) $this;
     }
 
-    /** @psalm-suppress ImpureFunctionCall */
     protected function resolveOptionalCallback(bool|Closure $cb) : bool
     {
         if ($cb instanceof Closure) {
+            /** @psalm-suppress ImpureFunctionCall */
             return (bool) $cb($this);
         }
 

--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -657,10 +657,11 @@ final class BigDecimal extends BigNumber
         return (float) (string) $this;
     }
 
+    /** @psalm-suppress ImpureFunctionCall */
     protected function resolveOptionalCallback(bool|Closure $cb) : bool
     {
         if ($cb instanceof Closure) {
-            return $cb($this);
+            return (bool) $cb($this);
         }
 
         return $cb;

--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -522,6 +522,8 @@ final class BigDecimal extends BigNumber
 
     /**
      * Returns the absolute value of this number.
+     *
+     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the absolute value should be returned. Receives $this as an argument.
      */
     public function abs(bool|Closure $abs = true) : BigDecimal
     {
@@ -534,6 +536,8 @@ final class BigDecimal extends BigNumber
 
     /**
      * Returns the negated value of this number.
+     *
+     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the negated value should be returned. Receives $this as an argument.
      */
     public function negated(bool|Closure $negated = true) : BigDecimal
     {

--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -523,7 +523,7 @@ final class BigDecimal extends BigNumber
     /**
      * Returns the absolute value of this number.
      *
-     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the absolute value should be returned. Receives $this as an argument.
+     * @param bool|Closure $abs A boolean or callback that will be evaluated to determine if the absolute value should be returned. Receives $this as an argument.
      */
     public function abs(bool|Closure $abs = true) : BigDecimal
     {
@@ -537,7 +537,7 @@ final class BigDecimal extends BigNumber
     /**
      * Returns the negated value of this number.
      *
-     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the negated value should be returned. Receives $this as an argument.
+     * @param bool|Closure $negated A boolean or callback that will be evaluated to determine if the negated value should be returned. Receives $this as an argument.
      */
     public function negated(bool|Closure $negated = true) : BigDecimal
     {

--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -8,6 +8,7 @@ use Brick\Math\Exception\DivisionByZeroException;
 use Brick\Math\Exception\MathException;
 use Brick\Math\Exception\NegativeNumberException;
 use Brick\Math\Internal\Calculator;
+use Closure;
 
 /**
  * Immutable, arbitrary-precision signed decimal numbers.
@@ -522,17 +523,25 @@ final class BigDecimal extends BigNumber
     /**
      * Returns the absolute value of this number.
      */
-    public function abs() : BigDecimal
+    public function abs(bool|Closure $abs = true) : BigDecimal
     {
-        return $this->isNegative() ? $this->negated() : $this;
+        if ($this->resolveOptionalCallback($abs)) {
+            return $this->isNegative() ? $this->negated() : $this;
+        }
+
+        return $this;
     }
 
     /**
      * Returns the negated value of this number.
      */
-    public function negated() : BigDecimal
+    public function negated(bool|Closure $negated = true) : BigDecimal
     {
-        return new BigDecimal(Calculator::get()->neg($this->value), $this->scale);
+        if ($this->resolveOptionalCallback($negated)) {
+            return new BigDecimal(Calculator::get()->neg($this->value), $this->scale);
+        }
+
+        return $this;
     }
 
     public function compareTo(BigNumber|int|float|string $that) : int
@@ -646,6 +655,15 @@ final class BigDecimal extends BigNumber
     public function toFloat() : float
     {
         return (float) (string) $this;
+    }
+
+    protected function resolveOptionalCallback(bool|Closure $cb) : bool
+    {
+        if ($cb instanceof Closure) {
+            return $cb($this);
+        }
+
+        return $cb;
     }
 
     public function __toString() : string

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -1022,10 +1022,11 @@ final class BigInteger extends BigNumber
         return \hex2bin($hex);
     }
 
+    /** @psalm-suppress ImpureFunctionCall */
     protected function resolveOptionalCallback(bool|Closure $cb) : bool
     {
         if ($cb instanceof Closure) {
-            return $cb($this);
+            return (bool) $cb($this);
         }
 
         return $cb;

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -682,7 +682,7 @@ final class BigInteger extends BigNumber
     /**
      * Returns the absolute value of this number.
      *
-     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the absolute value should be returned. Receives $this as an argument.
+     * @param bool|Closure $abs A boolean or callback that will be evaluated to determine if the absolute value should be returned. Receives $this as an argument.
      */
     public function abs(bool|Closure $abs = true) : BigInteger
     {
@@ -696,7 +696,7 @@ final class BigInteger extends BigNumber
     /**
      * Returns the inverse of this number.
      *
-     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the negated value should be returned. Receives $this as an argument.
+     * @param bool|Closure $negated A boolean or callback that will be evaluated to determine if the negated value should be returned. Receives $this as an argument.
      */
     public function negated(bool|Closure $negated = true) : BigInteger
     {

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -1026,10 +1026,10 @@ final class BigInteger extends BigNumber
         return \hex2bin($hex);
     }
 
-    /** @psalm-suppress ImpureFunctionCall */
     protected function resolveOptionalCallback(bool|Closure $cb) : bool
     {
         if ($cb instanceof Closure) {
+            /** @psalm-suppress ImpureFunctionCall */
             return (bool) $cb($this);
         }
 

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -10,6 +10,7 @@ use Brick\Math\Exception\MathException;
 use Brick\Math\Exception\NegativeNumberException;
 use Brick\Math\Exception\NumberFormatException;
 use Brick\Math\Internal\Calculator;
+use Closure;
 
 /**
  * An arbitrary-size integer.
@@ -681,17 +682,25 @@ final class BigInteger extends BigNumber
     /**
      * Returns the absolute value of this number.
      */
-    public function abs() : BigInteger
+    public function abs(bool|Closure $abs = true) : BigInteger
     {
-        return $this->isNegative() ? $this->negated() : $this;
+        if ($this->resolveOptionalCallback($abs)) {
+            return $this->isNegative() ? $this->negated() : $this;
+        }
+
+        return $this;
     }
 
     /**
      * Returns the inverse of this number.
      */
-    public function negated() : BigInteger
+    public function negated(bool|Closure $negated = true) : BigInteger
     {
-        return new BigInteger(Calculator::get()->neg($this->value));
+        if ($this->resolveOptionalCallback($negated)) {
+            return new BigInteger(Calculator::get()->neg($this->value));
+        }
+
+        return $this;
     }
 
     /**
@@ -1011,6 +1020,15 @@ final class BigInteger extends BigNumber
         }
 
         return \hex2bin($hex);
+    }
+
+    protected function resolveOptionalCallback(bool|Closure $cb) : bool
+    {
+        if ($cb instanceof Closure) {
+            return $cb($this);
+        }
+
+        return $cb;
     }
 
     public function __toString() : string

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -681,6 +681,8 @@ final class BigInteger extends BigNumber
 
     /**
      * Returns the absolute value of this number.
+     *
+     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the absolute value should be returned. Receives $this as an argument.
      */
     public function abs(bool|Closure $abs = true) : BigInteger
     {
@@ -693,6 +695,8 @@ final class BigInteger extends BigNumber
 
     /**
      * Returns the inverse of this number.
+     *
+     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the negated value should be returned. Receives $this as an argument.
      */
     public function negated(bool|Closure $negated = true) : BigInteger
     {

--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -295,7 +295,7 @@ final class BigRational extends BigNumber
     /**
      * Returns the absolute value of this BigRational.
      *
-     * @param bool|Closure $cb A callback that will be called with the BigRational as argument.
+     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the absolute value should be returned. Receives $this as an argument.
      */
     public function abs(bool|Closure $abs = true) : BigRational
     {
@@ -308,6 +308,8 @@ final class BigRational extends BigNumber
 
     /**
      * Returns the negated value of this BigRational.
+     *
+     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the negated value should be returned. Receives $this as an argument.
      */
     public function negated(bool|Closure $negated = true) : BigRational
     {

--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -8,6 +8,7 @@ use Brick\Math\Exception\DivisionByZeroException;
 use Brick\Math\Exception\MathException;
 use Brick\Math\Exception\NumberFormatException;
 use Brick\Math\Exception\RoundingNecessaryException;
+use Closure;
 
 /**
  * An arbitrarily large rational number.
@@ -293,18 +294,28 @@ final class BigRational extends BigNumber
 
     /**
      * Returns the absolute value of this BigRational.
+     *
+     * @param bool|Closure $cb A callback that will be called with the BigRational as argument.
      */
-    public function abs() : BigRational
+    public function abs(bool|Closure $abs = true) : BigRational
     {
-        return new BigRational($this->numerator->abs(), $this->denominator, false);
+        if ($this->resolveOptionalCallback($abs)) {
+            return new BigRational($this->numerator->abs(), $this->denominator, false);
+        }
+
+        return $this;
     }
 
     /**
      * Returns the negated value of this BigRational.
      */
-    public function negated() : BigRational
+    public function negated(bool|Closure $negated = true) : BigRational
     {
-        return new BigRational($this->numerator->negated(), $this->denominator, false);
+        if ($this->resolveOptionalCallback($negated)) {
+            return new BigRational($this->numerator->negated(), $this->denominator, false);
+        }
+
+        return $this;
     }
 
     /**
@@ -365,6 +376,15 @@ final class BigRational extends BigNumber
     {
         $simplified = $this->simplified();
         return $simplified->numerator->toFloat() / $simplified->denominator->toFloat();
+    }
+
+    protected function resolveOptionalCallback(bool|Closure $cb) : bool
+    {
+        if ($cb instanceof Closure) {
+            return $cb($this);
+        }
+
+        return $cb;
     }
 
     public function __toString() : string

--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -378,10 +378,11 @@ final class BigRational extends BigNumber
         return $simplified->numerator->toFloat() / $simplified->denominator->toFloat();
     }
 
+    /** @psalm-suppress ImpureFunctionCall */
     protected function resolveOptionalCallback(bool|Closure $cb) : bool
     {
         if ($cb instanceof Closure) {
-            return $cb($this);
+            return (bool) $cb($this);
         }
 
         return $cb;

--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -380,10 +380,10 @@ final class BigRational extends BigNumber
         return $simplified->numerator->toFloat() / $simplified->denominator->toFloat();
     }
 
-    /** @psalm-suppress ImpureFunctionCall */
     protected function resolveOptionalCallback(bool|Closure $cb) : bool
     {
         if ($cb instanceof Closure) {
+            /** @psalm-suppress ImpureFunctionCall */
             return (bool) $cb($this);
         }
 

--- a/src/BigRational.php
+++ b/src/BigRational.php
@@ -295,7 +295,7 @@ final class BigRational extends BigNumber
     /**
      * Returns the absolute value of this BigRational.
      *
-     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the absolute value should be returned. Receives $this as an argument.
+     * @param bool|Closure $abs A boolean or callback that will be evaluated to determine if the absolute value should be returned. Receives $this as an argument.
      */
     public function abs(bool|Closure $abs = true) : BigRational
     {
@@ -309,7 +309,7 @@ final class BigRational extends BigNumber
     /**
      * Returns the negated value of this BigRational.
      *
-     * @param bool|Closure $cb A boolean or callback that will be evaluated to determine if the negated value should be returned. Receives $this as an argument.
+     * @param bool|Closure $negated A boolean or callback that will be evaluated to determine if the negated value should be returned. Receives $this as an argument.
      */
     public function negated(bool|Closure $negated = true) : BigRational
     {

--- a/tests/BigDecimalTest.php
+++ b/tests/BigDecimalTest.php
@@ -11,6 +11,7 @@ use Brick\Math\Exception\NegativeNumberException;
 use Brick\Math\Exception\NumberFormatException;
 use Brick\Math\Exception\RoundingNecessaryException;
 use Brick\Math\RoundingMode;
+use Closure;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -2003,9 +2004,9 @@ class BigDecimalTest extends AbstractTestCase
      * @param int    $scale         The expected scale of the absolute result.
      */
     #[DataProvider('providerAbs')]
-    public function testAbs(string $number, string $unscaledValue, int $scale) : void
+    public function testAbs(string $number, string $unscaledValue, int $scale, bool|Closure $callback = true) : void
     {
-        self::assertBigDecimalInternalValues($unscaledValue, $scale, BigDecimal::of($number)->abs());
+        self::assertBigDecimalInternalValues($unscaledValue, $scale, BigDecimal::of($number)->abs($callback));
     }
 
     public static function providerAbs() : array
@@ -2014,7 +2015,19 @@ class BigDecimalTest extends AbstractTestCase
             ['123', '123', 0],
             ['-123', '123', 0],
             ['123.456', '123456', 3],
-            ['-123.456', '123456', 3]
+            ['-123.456', '123456', 3],
+            ['123', '123', 0, fn() => true],
+            ['-123', '123', 0, fn() => true],
+            ['123.456', '123456', 3, fn() => true],
+            ['-123.456', '123456', 3, fn() => true],
+            ['123', '123', 0, false],
+            ['-123', '-123', 0, false],
+            ['123.456', '123456', 3, false],
+            ['-123.456', '-123456', 3, false],
+            ['123', '123', 0, fn () => false],
+            ['-123', '-123', 0, fn () => false],
+            ['123.456', '123456', 3, fn () => false],
+            ['-123.456', '-123456', 3, fn () => false],
         ];
     }
 
@@ -2024,9 +2037,9 @@ class BigDecimalTest extends AbstractTestCase
      * @param int    $scale         The expected scale of the result.
      */
     #[DataProvider('providerNegated')]
-    public function testNegated(string $number, string $unscaledValue, int $scale) : void
+    public function testNegated(string $number, string $unscaledValue, int $scale, bool|Closure $callback = true) : void
     {
-        self::assertBigDecimalInternalValues($unscaledValue, $scale, BigDecimal::of($number)->negated());
+        self::assertBigDecimalInternalValues($unscaledValue, $scale, BigDecimal::of($number)->negated($callback));
     }
 
     public static function providerNegated() : array
@@ -2035,7 +2048,19 @@ class BigDecimalTest extends AbstractTestCase
             ['123', '-123', 0],
             ['-123', '123', 0],
             ['123.456', '-123456', 3],
-            ['-123.456', '123456', 3]
+            ['-123.456', '123456', 3],
+            ['123', '-123', 0, fn () => true],
+            ['-123', '123', 0, fn () => true],
+            ['123.456', '-123456', 3, fn () => true],
+            ['-123.456', '123456', 3, fn () => true],
+            ['123', '123', 0, false],
+            ['-123', '-123', 0, false],
+            ['123.456', '123456', 3, false],
+            ['-123.456', '-123456', 3, false],
+            ['123', '123', 0, fn () => false],
+            ['-123', '-123', 0, fn () => false],
+            ['123.456', '123456', 3, fn () => false],
+            ['-123.456', '-123456', 3, fn () => false],
         ];
     }
 

--- a/tests/BigIntegerTest.php
+++ b/tests/BigIntegerTest.php
@@ -13,6 +13,7 @@ use Brick\Math\Exception\DivisionByZeroException;
 use Brick\Math\Exception\RoundingNecessaryException;
 use Brick\Math\Internal\Calculator;
 use Brick\Math\RoundingMode;
+use Closure;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -1989,9 +1990,9 @@ class BigIntegerTest extends AbstractTestCase
      * @param string $expected The expected absolute result.
      */
     #[DataProvider('providerAbs')]
-    public function testAbs(string $number, string $expected) : void
+    public function testAbs(string $number, string $expected, bool|Closure $callback = true) : void
     {
-        self::assertBigIntegerEquals($expected, BigInteger::of($number)->abs());
+        self::assertBigIntegerEquals($expected, BigInteger::of($number)->abs($callback));
     }
 
     public static function providerAbs() : array
@@ -2000,6 +2001,15 @@ class BigIntegerTest extends AbstractTestCase
             ['0', '0'],
             ['123456789012345678901234567890', '123456789012345678901234567890'],
             ['-123456789012345678901234567890', '123456789012345678901234567890'],
+            ['0', '0', fn () => true],
+            ['123456789012345678901234567890', '123456789012345678901234567890', fn () => true],
+            ['-123456789012345678901234567890', '123456789012345678901234567890', fn () => true],
+            ['0', '0', false],
+            ['123456789012345678901234567890', '123456789012345678901234567890', false],
+            ['-123456789012345678901234567890', '-123456789012345678901234567890', false],
+            ['0', '0', fn () => false],
+            ['123456789012345678901234567890', '123456789012345678901234567890', fn () => false],
+            ['-123456789012345678901234567890', '-123456789012345678901234567890', fn () => false],
         ];
     }
 
@@ -2008,9 +2018,9 @@ class BigIntegerTest extends AbstractTestCase
      * @param string $expected The expected negated result.
      */
     #[DataProvider('providerNegated')]
-    public function testNegated(string $number, string $expected) : void
+    public function testNegated(string $number, string $expected, bool|Closure $callback = true) : void
     {
-        self::assertBigIntegerEquals($expected, BigInteger::of($number)->negated());
+        self::assertBigIntegerEquals($expected, BigInteger::of($number)->negated($callback));
     }
 
     public static function providerNegated() : array
@@ -2019,6 +2029,15 @@ class BigIntegerTest extends AbstractTestCase
             ['0', '0'],
             ['123456789012345678901234567890', '-123456789012345678901234567890'],
             ['-123456789012345678901234567890', '123456789012345678901234567890'],
+            ['0', '0', fn () => true],
+            ['123456789012345678901234567890', '-123456789012345678901234567890', fn () => true],
+            ['-123456789012345678901234567890', '123456789012345678901234567890', fn () => true],
+            ['0', '0', false],
+            ['123456789012345678901234567890', '123456789012345678901234567890', false],
+            ['-123456789012345678901234567890', '-123456789012345678901234567890', false],
+            ['0', '0', fn () => false],
+            ['123456789012345678901234567890', '123456789012345678901234567890', fn () => false],
+            ['-123456789012345678901234567890', '-123456789012345678901234567890', fn () => false],
         ];
     }
 

--- a/tests/BigRationalTest.php
+++ b/tests/BigRationalTest.php
@@ -12,6 +12,7 @@ use Brick\Math\Exception\MathException;
 use Brick\Math\Exception\NumberFormatException;
 use Brick\Math\Exception\RoundingNecessaryException;
 use Brick\Math\RoundingMode;
+use Closure;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -433,9 +434,9 @@ class BigRationalTest extends AbstractTestCase
      * @param string $expected The expected absolute number.
      */
     #[DataProvider('providerAbs')]
-    public function testAbs(string $rational, string $expected) : void
+    public function testAbs(string $rational, string $expected, bool|Closure $callback = true) : void
     {
-        self::assertBigRationalEquals($expected, BigRational::of($rational)->abs());
+        self::assertBigRationalEquals($expected, BigRational::of($rational)->abs($callback));
     }
 
     public static function providerAbs() : array
@@ -447,6 +448,24 @@ class BigRationalTest extends AbstractTestCase
             ['123/456', '123/456'],
             ['-234/567', '234/567'],
             ['-489798742123504998877665/387590928349859112233445', '489798742123504998877665/387590928349859112233445'],
+            ['0', '0', fn () => true],
+            ['1', '1', fn () => true],
+            ['-1', '1', fn () => true],
+            ['123/456', '123/456', fn () => true],
+            ['-234/567', '234/567', fn () => true],
+            ['-489798742123504998877665/387590928349859112233445', '489798742123504998877665/387590928349859112233445', fn () => true],
+            ['0', '0', false],
+            ['1', '1', false],
+            ['-1', '-1', false],
+            ['123/456', '123/456', false],
+            ['-234/567', '-234/567', false],
+            ['-489798742123504998877665/387590928349859112233445', '-489798742123504998877665/387590928349859112233445', false],
+            ['0', '0', fn () => false],
+            ['1', '1', fn () => false],
+            ['-1', '-1', fn () => false],
+            ['123/456', '123/456', fn () => false],
+            ['-234/567', '-234/567', fn () => false],
+            ['-489798742123504998877665/387590928349859112233445', '-489798742123504998877665/387590928349859112233445', fn () => false],
         ];
     }
 
@@ -455,9 +474,9 @@ class BigRationalTest extends AbstractTestCase
      * @param string $expected The expected negated number.
      */
     #[DataProvider('providerNegated')]
-    public function testNegated(string $rational, string $expected) : void
+    public function testNegated(string $rational, string $expected, bool|Closure $callback = true) : void
     {
-        self::assertBigRationalEquals($expected, BigRational::of($rational)->negated());
+        self::assertBigRationalEquals($expected, BigRational::of($rational)->negated($callback));
     }
 
     public static function providerNegated() : array
@@ -470,6 +489,27 @@ class BigRationalTest extends AbstractTestCase
             ['-234/567', '234/567'],
             ['-489798742123504998877665/387590928349859112233445', '489798742123504998877665/387590928349859112233445'],
             ['489798742123504998877665/387590928349859112233445', '-489798742123504998877665/387590928349859112233445'],
+            ['0', '0', fn () => true],
+            ['1', '-1', fn () => true],
+            ['-1', '1', fn () => true],
+            ['123/456', '-123/456', fn () => true],
+            ['-234/567', '234/567', fn () => true],
+            ['-489798742123504998877665/387590928349859112233445', '489798742123504998877665/387590928349859112233445', fn () => true],
+            ['489798742123504998877665/387590928349859112233445', '-489798742123504998877665/387590928349859112233445', fn () => true],
+            ['0', '0', false],
+            ['1', '1', false],
+            ['-1', '-1', false],
+            ['123/456', '123/456', false],
+            ['-234/567', '-234/567', false],
+            ['-489798742123504998877665/387590928349859112233445', '-489798742123504998877665/387590928349859112233445', false],
+            ['489798742123504998877665/387590928349859112233445', '489798742123504998877665/387590928349859112233445', false],
+            ['0', '0', fn () => false],
+            ['1', '1', fn () => false],
+            ['-1', '-1', fn () => false],
+            ['123/456', '123/456', fn () => false],
+            ['-234/567', '-234/567', fn () => false],
+            ['-489798742123504998877665/387590928349859112233445', '-489798742123504998877665/387590928349859112233445', fn () => false],
+            ['489798742123504998877665/387590928349859112233445', '489798742123504998877665/387590928349859112233445', fn () => false],
         ];
     }
 


### PR DESCRIPTION
This tickets resolves #84.

Added tests to cover off true/false and closures that return the same. The idea here is that you can optionally assign whether or not you want to make a value absolute or negated based on a logic gate inline. Compare the two code examples of how this is done:

What you would have to do before:

```php
$number = $number->multipliedBy(3)
  ->dividedBy(2);

if ($number->toInt() % 2 === 0) {
  $number = $number->negated();
}

return $number->add(5)->toInt();
```

And what this allows you to do now:

```php
return $number->multipliedBy(3)
  ->dividedBy(2)
  ->negated(fn (BigNumber $number) => $number->toInt() % 2 === 0)
  ->add(5)
  ->toInt();
```

or 


```php
function getBalance(bool $accountIsCreditNormal) {
    return $number->multipliedBy(3)
      ->dividedBy(2)
      ->negated($accountIsCreditNormal)
      ->add(5)
      ->toInt();
}
```

Syntax is much more clear and succinct. My use case for this as outlined in #84 is to bring this into brick/money where we require this where we're manipulating values in an accounting system. 