### PR TITLE
Force numeric-string return type in BigDecimal::__toString() and BigInteger::__toString()

### DIFF
--- a/src/BigDecimal.php
+++ b/src/BigDecimal.php
@@ -689,15 +689,20 @@ final class BigDecimal extends BigNumber
         return (float) (string) $this;
     }
 
+    /**
+     * @return numeric-string
+     */
     #[Override]
     public function __toString() : string
     {
         if ($this->scale === 0) {
+            /** @var numeric-string */
             return $this->value;
         }
 
         $value = $this->getUnscaledValueWithLeadingZeros();
 
+        /** @var numeric-string */
         return \substr($value, 0, -$this->scale) . '.' . \substr($value, -$this->scale);
     }
 

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -1023,9 +1023,13 @@ final class BigInteger extends BigNumber
         return \hex2bin($hex);
     }
 
+    /**
+     * @return numeric-string
+     */
     #[Override]
     public function __toString() : string
     {
+        /** @var numeric-string */
         return $this->value;
     }
 


### PR DESCRIPTION
Closes #89.

`@return numeric-string` cannot be added to `BigRational`, because `'10/20'` is not a numeric string. So I added `numeric-string` to `BigDecimal` and `BigInteger` classes only. This does not break LSP, because methods return types are covariant and `numeric-string <: string`.

I forced types via `@var` annotation, otherwise the refactoring would be huge and still in most places we will have to force type, for example where `$sign` is concatenated with `$value`.