### PR TITLE
Fix incorrect multiplication example in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ return a new object, leaving the original object unaffected:
 $ten = BigInteger::of(10);
 
 echo $ten->plus(5); // 15
-echo $ten->multipliedBy(3); // 30
+echo $ten->multipliedBy(3); // 45
 ```
 
 The methods can be chained for better readability:


### PR DESCRIPTION
Fixed an error in the documentation example where the result of multipliedBy() was incorrect.