### PR TITLE
PHP 8.5: Fix casting warnings in BigInteger::toInt() and BigNumber::of()

### DIFF
--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -18,6 +18,7 @@ use Override;
 use function assert;
 use function bin2hex;
 use function chr;
+use function filter_var;
 use function hex2bin;
 use function in_array;
 use function intdiv;
@@ -31,6 +32,8 @@ use function str_repeat;
 use function strlen;
 use function strtolower;
 use function substr;
+
+use const FILTER_VALIDATE_INT;
 
 /**
  * An arbitrary-size integer.
@@ -979,9 +982,9 @@ final readonly class BigInteger extends BigNumber
     #[Override]
     public function toInt(): int
     {
-        $intValue = (int) $this->value;
+        $intValue = filter_var($this->value, FILTER_VALIDATE_INT);
 
-        if ($this->value !== (string) $intValue) {
+        if ($intValue === false) {
             throw IntegerOverflowException::toIntOverflow($this);
         }
 

--- a/src/BigNumber.php
+++ b/src/BigNumber.php
@@ -17,6 +17,7 @@ use function array_shift;
 use function assert;
 use function is_float;
 use function is_int;
+use function is_nan;
 use function ltrim;
 use function preg_match;
 use function str_contains;
@@ -456,7 +457,11 @@ abstract readonly class BigNumber implements JsonSerializable, Stringable
         }
 
         if (is_float($value)) {
-            $value = (string) $value;
+            if (is_nan($value)) {
+                $value = 'NAN';
+            } else {
+                $value = (string) $value;
+            }
         }
 
         if (str_contains($value, '/')) {


### PR DESCRIPTION
* Fix #100
* Fix `NAN` casting issue in BigNumber.